### PR TITLE
bug(screenshot): incorrect screenshot area when selecting from top-right, bottom-right, or bottom-left

### DIFF
--- a/pages/content/src/capture/screenshot.capture.ts
+++ b/pages/content/src/capture/screenshot.capture.ts
@@ -50,14 +50,6 @@ const cropSelectedArea = (
     throw new Error('Failed to get 2D context for cropped canvas.');
   }
 
-  // Correct cropping offsets and alignment
-  const adjustedStartX = startX - window.scrollX;
-  const adjustedStartY = startY - window.scrollY;
-
-  // Calculate the ratio based on the full-page canvas size and the visible viewport size
-  const ratioX = canvas.width / window.innerWidth;
-  const ratioY = canvas.height / window.innerHeight;
-
   ctx.drawImage(
     canvas,
     x * scaleFactor,
@@ -69,18 +61,6 @@ const cropSelectedArea = (
     width * scaleFactor,
     height * scaleFactor,
   );
-
-  // ctx?.drawImage(
-  //   canvas, // Use the full-page canvas as the sources
-  //   adjustedStartX * ratioX, // Adjust X coordinate
-  //   adjustedStartY * ratioY, // Adjust Y coordinate
-  //   width * ratioX, // Adjust width with ratio
-  //   height * ratioY, // Adjust height with ratio
-  //   0, // X coordinate in the cropped canvas
-  //   0, // Y coordinate in the cropped canvas
-  //   width * scaleFactor, // Apply scale factor for better resolution
-  //   height * scaleFactor, // Apply scale factor for better resolution
-  // );
 
   return croppedCanvas;
 };


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [x] High: This PR needs to be merged first, before other tasks.
- [ ] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
<!-- Describe the purpose of the PR. -->
This PR fixes Incorrect screenshot area when selecting from top-right, bottom-right, or bottom-left when crop happened.

## Changes*
I've refactored the screenshot logic to fix the issue where the screenshot area didn't match the selection when starting from top-right, bottom-right, or bottom-left. The fix ensures that the correct top-left and bottom-right coordinates are always used for selection and cropping.

## How to check the feature
<!-- Describe how to check the feature in detail -->
<!-- If there are any visual changes, please attach a screenshot for easy identification. -->
Select Area option, and try selecting from top-right, bottom-right, or bottom-left 

## Reference
<!-- Any helpful information for understanding the PR. -->
Fixes #65 