### PR TITLE
bug(73): selection box is not hidden when capturing the screenshot

### DIFF
--- a/packages/shared/lib/utils/redact-sensitive-info.util.ts
+++ b/packages/shared/lib/utils/redact-sensitive-info.util.ts
@@ -50,7 +50,7 @@ const safeRedact = (value: string): string => {
  * Internal recursive function that uses a single precomputed redaction flag.
  */
 const deepRedactInternal = (input: any, shouldSkipRedaction: boolean): any => {
-  if (shouldSkipRedaction) return input;
+  if (shouldSkipRedaction || !input) return input;
 
   if (typeof input !== 'object' && typeof input !== 'string') return input;
 
@@ -70,6 +70,8 @@ const deepRedactInternal = (input: any, shouldSkipRedaction: boolean): any => {
   if (Array.isArray(input)) {
     return input.map(item => deepRedactInternal(item, shouldSkipRedaction));
   }
+
+  if (typeof input !== 'object') return input;
 
   const result: Record<string, any> = {};
   for (const [key, value] of Object.entries(input)) {


### PR DESCRIPTION
<!-- Note: Please ensure your PR is targeting the `dev` branch -->
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority\*

* [ ] High: This PR needs to be merged first, before other tasks.
* [x] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
* [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR\*
Fixes an intermittent bug where the selection box was still visible in the captured screenshot when using the "Select Area" feature.

## Changes\*
* Added `ignoreElements` to `html2canvas` config to explicitly exclude temporary UI (selection box, overlay, dimension label).
* Removed unnecessary `Promise` wrapper around the `cleanup` function; made it synchronous.
* Introduced a `waitForRepaint()` utility using `requestAnimationFrame + setTimeout` to ensure the DOM has been visually updated before taking the screenshot.

## How to check the feature

1. Launch the extension and use the "Select Area" screenshot mode.
2. Click and drag to draw the selection box.
3. Capture multiple times to ensure consistency.
4. Verify that the selection box does **not** appear in any screenshot.
5. Edge test: try quickly dragging and releasing the box, it should still not be captured.

## Reference
Closes #73 
