### PR TITLE
bug(#35): when capturing a second screenshot, metadata is missing, unless the page is reloaded

### DIFF
--- a/chrome-extension/src/utils/manage-records.util.ts
+++ b/chrome-extension/src/utils/manage-records.util.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { deepRedactSensitiveInfo } from '@extension/shared';
 
-const restricted = ['briehq']; // 'extend.iife',  'kbmbnelnoppneadncmmkfikbcgmilbao'  Note: it blocks the logs
+const restricted = ['https://api.briehq.com']; // 'extend.iife',  'kbmbnelnoppneadncmmkfikbcgmilbao'  Note: it blocks the logs
 const invalidRecord = (entity: string) => restricted.some(word => entity.includes(word));
 
 const tabRecordsMap = new Map<number, Map<string, any>>();
@@ -30,16 +30,14 @@ export const getRecords = async (tabId: number): Promise<Record[]> => {
 
 export const addOrMergeRecords = async (tabId: number, record: Record | any): Promise<void> => {
   if (!tabId || tabId === -1) {
-    console.log('[addOrMergeRecords] tabId is null OR -1');
+    console.log('[addOrMergeRecords] SKIPPED: Invalid TabId (null OR -1)');
     return;
   }
 
-  if (invalidRecord(record?.url || '')) return;
-
-  // if (record.recordType === 'console' && invalidRecord(record.stackTrace.parsed)) {
-  //   console.log('record console', record);
-  //   return;
-  // }
+  if (invalidRecord(record?.url || '')) {
+    console.log('[addOrMergeRecords] SKIPPED: Invalid URL');
+    return;
+  }
 
   const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
   const tabUrl = tab?.url || record?.url;

--- a/pages/content/src/event-listeners/runtime.event-listeners.ts
+++ b/pages/content/src/event-listeners/runtime.event-listeners.ts
@@ -1,10 +1,10 @@
 import { cleanup, startScreenshotCapture } from '@src/capture';
 
 export const addRuntimeEventListeners = () => {
-  // Listen for runtime messages
   chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     if (msg.action === 'START_SCREENSHOT') {
-      // Call the function to initiate the screenshot capture process
+      window.dispatchEvent(new CustomEvent('metadata'));
+
       startScreenshotCapture(msg.payload);
     }
 

--- a/pages/content/src/event-listeners/window.event-listeners.ts
+++ b/pages/content/src/event-listeners/window.event-listeners.ts
@@ -8,7 +8,11 @@ export const addWindowEventListeners = () => {
     if (event.source !== window || !event.data.type) return;
 
     if (event.data.type === 'ADD_RECORD') {
-      chrome.runtime.sendMessage({ type: 'ADD_RECORD', data: event.data.payload });
+      try {
+        chrome.runtime.sendMessage({ type: 'ADD_RECORD', data: event.data.payload });
+      } catch (err) {
+        console.error('[sendMessage error]', chrome.runtime.id, err);
+      }
     }
   });
 };

--- a/pages/content/src/interceptors/events/events.interceptor.ts
+++ b/pages/content/src/interceptors/events/events.interceptor.ts
@@ -9,7 +9,7 @@ import {
 import { historyApiInterceptor } from './history.interceptor';
 
 export const trackEvent = ({ target, ...others }: any) => {
-  const description = getElementDescription(target);
+  const description = target ? getElementDescription(target) : null;
   const baseTimestamp = Date.now();
   const timestamp = others?.event === 'Navigate' ? baseTimestamp + 1000 : baseTimestamp;
 
@@ -102,19 +102,7 @@ export const interceptEvents = () => {
   });
 
   window.addEventListener('load', async () => {
-    const systemInfo = await getSystemInfo();
-
     trackEvent({ event: 'PageLoaded' });
-
-    trackEvent({
-      ...systemInfo,
-      event: 'metadata',
-      rowTimestamp: new Date().toISOString(),
-      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-      url: document.location.href,
-      window: { width: window.innerWidth, height: window.innerHeight },
-      screen: { width: window.screen.width, height: window.screen.height },
-    });
   });
 
   let hiddenAt: number | null = null;
@@ -249,6 +237,21 @@ export const interceptEvents = () => {
 
   document.addEventListener('mousedown', activateTracking);
   document.addEventListener('focusin', activateTracking, true);
+
+  // Custom Events
+  window.addEventListener('metadata', async () => {
+    const systemInfo = await getSystemInfo();
+
+    await trackEvent({
+      ...systemInfo,
+      event: 'metadata',
+      rowTimestamp: new Date().toISOString(),
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      url: document.location.href,
+      window: { width: window.innerWidth, height: window.innerHeight },
+      screen: { width: window.screen.width, height: window.screen.height },
+    });
+  });
 
   historyApiInterceptor();
 };


### PR DESCRIPTION
<!-- Note: Please ensure your PR is targeting the `develop` branch -->
<!-- Describe what this PR is for in the title. -->
<!-- `*` denotes required fields -->

## Purpose of the PR\*
This PR fixes the issue when capturing a second screenshot, metadata is missing unless the page is reloaded.
<!-- Describe the purpose of the PR. -->

## Priority\*

- [ ] High: This PR needs to be merged first, before other tasks.
- [x] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Changes\*
- Refactored `events.interceptor.ts` file.
- Separated custom event for receiving the metadata.

## How to check the feature
1. Open Ext
2. Click take screenshot
3. Create the bug report
4. Check Info tab content

<!-- Describe how to check the feature in detail -->
<!-- If there are any visual changes, please attach a screenshot for easy identification. -->

## Reference
Fixes #35 
<!-- Any helpful information for understanding the PR. -->
