### PR TITLE
Fix/177

### DIFF
--- a/.github/workflows/build-zip.yml
+++ b/.github/workflows/build-zip.yml
@@ -19,7 +19,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile --prefer-offline
 
-      - run: pnpm build
+      - run: pnpm base-build
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pr-target-branch.yml
+++ b/.github/workflows/pr-target-branch.yml
@@ -1,9 +1,7 @@
 name: Make sure PRs are targeted to `develop`.
 
-on:
-  pull_request:
-    types: [opened, edited, reopened]
-
+on: pull_request_target
+   
 jobs:
   check-branch:
     runs-on: ubuntu-latest

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -11,20 +11,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Run Prettier
-        id: prettier-run
-        uses: rutajdash/prettier-cli-action@v1.0.0
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          config_path: ./.prettierrc
-          file_pattern: '*.{js,jsx,ts,tsx,json}'
+          node-version: '18'
 
-      # This step only runs if prettier finds errors causing the previous step to fail
-      # This steps lists the files where errors were found
-      - name: Prettier Output
-        if: ${{ failure() }}
-        shell: bash
+      - name: Install Prettier
+        run: npm install --global prettier@latest
+
+      - name: Check Prettier Formatting
         run: |
-          echo "The following files aren't formatted properly:"
-          echo "${{steps.prettier-run.outputs.prettier_output}}"
+          prettier --check \
+            --config ./.prettierrc \
+            --ignore-path ./.prettierignore \
+            --no-error-on-unmatched-pattern \
+            '**/*.{js,jsx,ts,tsx,json}'


### PR DESCRIPTION
<!-- Note: Please ensure your PR is targeting the `develop` branch -->
<!-- Describe what this PR is for in the title. -->
<!-- `*` denotes required fields -->

## Purpose of the PR\*
fixes #177 

<!-- Describe the purpose of the PR. -->

- Some of the workflows were failing on PR 

- Here are the details of the four workflows that were failing:

### Prettier

- The prettier workflow was failing due to using deprecated commands. The command `set-output` was not used in the  workflow itself though it was used in the third party  action that was integrated into the workflow `rutajdash/prettier-cli-action@v1.0.0`

- I also updated the checkout version `actions/checkout@v2` to `actions/checkout@v4` which is the latest stable version.

### check base branch on PR

- The workflow was using the wrong trigger `pull_request` instead of  `pull_request_target`

### Build

- Simple typo `build` => `base-build`

### lint

The lint gh worflow works and fails as expected.  When running `pnpm lint` locally, we do get the same errors appearing on the workflow.


## Priority\*

- [ ] High: This PR needs to be merged first, before other tasks.
- [x] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Changes\*

## How to check the feature

<!-- Describe how to check the feature in detail -->
<!-- If there are any visual changes, please attach a screenshot for easy identification. -->

## Reference

<!-- Any helpful information for understanding the PR. -->
