### PR TITLE
bug(#195): locales import statement is getting repeated on build

### DIFF
--- a/packages/i18n/lib/set_related_locale_import.ts
+++ b/packages/i18n/lib/set_related_locale_import.ts
@@ -7,33 +7,25 @@ import type { SupportedLanguagesKeysType, SupportedLanguagesWithoutRegionKeysTyp
 export default () => {
   const locale = Intl.DateTimeFormat().resolvedOptions().locale.replace('-', '_') as SupportedLanguagesKeysType;
   const localeWithoutRegion = locale.split('_')[0] as SupportedLanguagesWithoutRegionKeysType;
-
   const localesDir = resolve(import.meta.dirname, '..', '..', 'locales');
-  const readLocalesFolder = readdirSync(localesDir);
+  const implementedLocales = readdirSync(localesDir).filter(dir => lstatSync(resolve(localesDir, dir)).isDirectory());
 
-  const implementedLocales = readLocalesFolder.map(innerDir => {
-    if (lstatSync(resolve(localesDir, innerDir)).isDirectory()) {
-      return innerDir;
-    }
-    return;
-  });
+  const pickLocale = (): string => {
+    if (process.env.DEV_LOCALE) return process.env.DEV_LOCALE;
+    if (implementedLocales.includes(locale)) return locale;
+    if (implementedLocales.includes(localeWithoutRegion)) return localeWithoutRegion;
+    return 'en';
+  };
 
-  const i18nFileSplitContent = readFileSync(I18N_FILE_PATH, 'utf-8').split('\n');
+  const newImportLine = `import localeJSON from '../locales/${pickLocale()}/messages.json' with { type: 'json' };`;
+  const lines = readFileSync(I18N_FILE_PATH, 'utf-8').split(/\r?\n/);
+  const cleaned = lines.filter(line => !/^import\s+localeJSON/.test(line.trim()));
 
-  if (process.env['DEV_LOCALE']) {
-    i18nFileSplitContent[1] = `import localeJSON from '../locales/${process.env['DEV_LOCALE']}/messages.json' with { type: 'json' };`;
-  } else {
-    if (implementedLocales.includes(locale)) {
-      i18nFileSplitContent[1] = `import localeJSON from '../locales/${locale}/messages.json' with { type: 'json' };`;
-    } else if (implementedLocales.includes(localeWithoutRegion)) {
-      i18nFileSplitContent[1] = `import localeJSON from '../locales/${localeWithoutRegion}/messages.json' with { type: 'json' };`;
-    } else {
-      i18nFileSplitContent[1] = `import localeJSON from '../locales/en/messages.json' with { type: 'json' };`;
-    }
+  let insertAt = 0;
+  while (insertAt < cleaned.length && /^(['"])use\s+\w+['"];\s*$/.test(cleaned[insertAt].trim())) {
+    insertAt += 1;
   }
+  cleaned.splice(insertAt, 0, newImportLine);
 
-  // Join lines back together
-  const updatedI18nFile = i18nFileSplitContent.join('\n');
-
-  writeFileSync(I18N_FILE_PATH, updatedI18nFile, 'utf-8');
+  writeFileSync(I18N_FILE_PATH, `${cleaned.join('\n')}\n`, 'utf-8');
 };


### PR DESCRIPTION
<!-- Note: Please ensure your PR is targeting the `develop` branch -->
<!-- Describe what this PR is for in the title. -->
<!-- `*` denotes required fields -->

## Purpose of the PR\*
This PR fixes the issue when locales import statement is getting repeated on build
<!-- Describe the purpose of the PR. -->

## Priority\*

- [x] High: This PR needs to be merged first, before other tasks.
- [ ] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Changes\*
Changed `packages/i18n/lib/set_related_locale_import.ts`

## How to check the feature
Run the extension and it should build and run successful
<!-- Describe how to check the feature in detail -->
<!-- If there are any visual changes, please attach a screenshot for easy identification. -->

## Reference
Seems that this issue appears after fixing the ESLint issues #184 
<!-- Any helpful information for understanding the PR. -->
