### PR TITLE
bug(#170): device toggle and details are now tracked

### DIFF
--- a/pages/content/src/utils/events/system-info/detect-emulation.util.ts
+++ b/pages/content/src/utils/events/system-info/detect-emulation.util.ts
@@ -4,12 +4,16 @@
 export const isLikelyEmulated = (): boolean => {
   const dpr = window.devicePixelRatio;
   const ua = navigator.userAgent;
-  const isTouchSpoofed = navigator.maxTouchPoints > 0 && !('ontouchstart' in window);
+  const hasTouch = 'ontouchstart' in window;
+  const maxTouchPoints = navigator.maxTouchPoints || 0;
   const isMobileUA = /Mobi|Android|iPhone|iPad/i.test(ua);
   const isSmall = window.innerWidth < 800;
-  const isDPRMismatch = dpr >= 2 && screen.width < 800;
+  const spoofedTouch = maxTouchPoints > 0 && !hasTouch;
+  const suspiciousDesktopUA = !isMobileUA && isSmall;
+  const suspiciousZoomOrDPR = dpr >= 2 && screen.width < 800;
+  const emulatedButLooksReal = isMobileUA && isSmall && maxTouchPoints > 0;
 
-  return isTouchSpoofed || (!isMobileUA && isSmall) || isDPRMismatch;
+  return spoofedTouch || suspiciousDesktopUA || suspiciousZoomOrDPR || emulatedButLooksReal;
 };
 
 /**

--- a/pages/content/src/utils/events/system-info/system-info.util.ts
+++ b/pages/content/src/utils/events/system-info/system-info.util.ts
@@ -23,10 +23,10 @@ export const getSystemInfo = async (): Promise<SystemInfo> => {
   return {
     battery: batteryInfo,
     browser: {
-      ...systemInfo.browser,
+      ...(await systemInfo).browser,
       isIncognito,
     },
-    os: systemInfo.os,
+    os: (await systemInfo).os,
     network: getNetworkInfo(),
     locale: getLanguageInfo(),
     memory: getMemoryInfo(),

--- a/pages/content/src/utils/events/system-info/user-agent.util.ts
+++ b/pages/content/src/utils/events/system-info/user-agent.util.ts
@@ -3,47 +3,47 @@ import type { BrowserInfo, OSInfo } from '@src/interfaces/events';
 import { isDevToolsOpen, isLikelyEmulated } from './detect-emulation.util';
 import { getBrowserZoomLevel } from './zoom-level.util';
 
-/** Parses navigator.userAgent and userAgentData to extract browser and OS info. */
+/** Parses navigator.userAgent to extract browser and OS info. */
 export const parseUserAgent = (): { browser: BrowserInfo; os: OSInfo } => {
-  const uaData = navigator?.userAgentData || {};
-  const userAgent = navigator.userAgent;
+  const userAgent = navigator.userAgent.toLowerCase();
 
   let browserName = 'Unknown';
   let browserVersion = 'Unknown';
   let osName = 'Unknown';
   let osVersion = 'Unknown';
 
-  if (uaData?.brands) {
-    const browserInfo = uaData.brands.find(b =>
-      ['chrome', 'edge', 'safari'].some(name => b.brand.toLowerCase().includes(name)),
-    );
-    if (browserInfo) {
-      browserName = browserInfo.brand;
-      browserVersion = browserInfo.version;
-    }
-  } else {
-    const match = userAgent.match(/(Chrome|Firefox|Safari|Edg|Opera|Brave)\/([\d.]+)/);
-    if (match) {
-      browserName = match[1];
-      browserVersion = match[2];
-    }
+  // Browser detection
+  if (userAgent.includes('firefox') || userAgent.includes('Firefox')) {
+    browserName = 'Firefox';
+    browserVersion = userAgent.match(/firefox\/([\d.]+)/)?.[1] || 'Unknown';
+  } else if ((userAgent.includes('safari') || userAgent.includes('Safari')) && !userAgent.includes('chrome')) {
+    browserName = 'Safari';
+    browserVersion = userAgent.match(/version\/([\d.]+)/)?.[1] || 'Unknown';
+  } else if (userAgent.includes('Edg')) {
+    browserName = 'Edge';
+    browserVersion = userAgent.match(/edg\/([\d.]+)/)?.[1] || 'Unknown';
+  } else if (userAgent.includes('chrome') || userAgent.includes('Chrome')) {
+    browserName = 'Chrome';
+    browserVersion = userAgent.match(/Chrome\/(\d+)/i)?.[1] || 'Unknown';
+  } else if (userAgent.includes('Opera')) {
+    browserName = 'Opera';
+    browserVersion = userAgent.match(/opera\/([\d.]+)/)?.[1] || 'Unknown';
   }
 
-  const platform = uaData.platform?.toLowerCase() || navigator.platform?.toLowerCase() || '';
+  const platform = userAgent || '';
   if (platform.includes('mac')) {
     osName = 'Mac OS';
-    osVersion = userAgent.match(/Mac OS X ([\d_.]+)/)?.[1]?.replace(/_/g, '.') || 'Unknown';
   } else if (platform.includes('win')) {
     osName = 'Windows';
     osVersion = userAgent.match(/Windows NT ([\d.]+)/)?.[1] || 'Unknown';
-  } else if (platform.includes('linux')) {
-    osName = 'Linux';
+  } else if (/iphone|ipad|ipod/.test(userAgent)) {
+    osName = 'iOS';
+    osVersion = userAgent.match(/OS ([\d_]+)/i)?.[1]?.replace(/_/g, '.') || 'Unknown';
   } else if (platform.includes('android')) {
     osName = 'Android';
-    osVersion = userAgent.match(/Android ([\d.]+)/)?.[1] || 'Unknown';
-  } else if (/iphone|ipad|ipod/.test(userAgent.toLowerCase())) {
-    osName = 'iOS';
-    osVersion = userAgent.match(/OS ([\d_]+)/)?.[1]?.replace(/_/g, '.') || 'Unknown';
+    osVersion = userAgent.match(/Android ([\d.]+)/i)?.[1] || 'Unknown';
+  } else if (platform.includes('linux')) {
+    osName = 'Linux';
   }
 
   return {

--- a/pages/content/src/utils/events/system-info/user-agent.util.ts
+++ b/pages/content/src/utils/events/system-info/user-agent.util.ts
@@ -6,37 +6,48 @@ import { getBrowserZoomLevel } from './zoom-level.util';
 /** Parses navigator.userAgent to extract browser and OS info. */
 export const parseUserAgent = (): { browser: BrowserInfo; os: OSInfo } => {
   const userAgent = navigator.userAgent.toLowerCase();
-
+  const uaData = (navigator as any).userAgentData || {};
+  const platform = userAgent || '';
   let browserName = 'Unknown';
   let browserVersion = 'Unknown';
   let osName = 'Unknown';
   let osVersion = 'Unknown';
 
-  // Browser detection
-  if (userAgent.includes('firefox') || userAgent.includes('Firefox')) {
-    browserName = 'Firefox';
-    browserVersion = userAgent.match(/firefox\/([\d.]+)/)?.[1] || 'Unknown';
-  } else if ((userAgent.includes('safari') || userAgent.includes('Safari')) && !userAgent.includes('chrome')) {
-    browserName = 'Safari';
-    browserVersion = userAgent.match(/version\/([\d.]+)/)?.[1] || 'Unknown';
-  } else if (userAgent.includes('Edg')) {
-    browserName = 'Edge';
-    browserVersion = userAgent.match(/edg\/([\d.]+)/)?.[1] || 'Unknown';
-  } else if (userAgent.includes('chrome') || userAgent.includes('Chrome')) {
-    browserName = 'Chrome';
-    browserVersion = userAgent.match(/Chrome\/(\d+)/i)?.[1] || 'Unknown';
-  } else if (userAgent.includes('Opera')) {
-    browserName = 'Opera';
-    browserVersion = userAgent.match(/opera\/([\d.]+)/)?.[1] || 'Unknown';
+  //   FIrst approach would be :
+  //   detect browser using browser name and browser version using uaData !
+  // uaData - for browser : Chrome, Edge, Opera, Dia, Brave, Samsung Internet as they are chromium based
+
+  const brands = uaData.brands;
+  browserName = brands[0].brand;
+  browserVersion = brands[0].version;
+
+  //  for non chromium based browser (Firefox / Safari) running on macos or on lInux
+  if (browserName === 'Unknown' && browserVersion === 'Unknown') {
+    // for firefox
+    if (userAgent.includes('firefox') || userAgent.includes('Firefox')) {
+      browserName = 'Firefox';
+      browserVersion = userAgent.match(/firefox\/([\d.]+)/)?.[1] || '';
+      const matchMac = userAgent.match(/Mac OS /i);
+      const matchLinux = userAgent.match(/Linux/i);
+      if (matchMac) {
+        osName = 'Mac OS';
+      } else if (matchLinux) {
+        osName = 'Linux';
+      }
+    }
+
+    // for safari
+    if ((userAgent.includes('safari') || userAgent.includes('Safari')) && !userAgent.includes('chrome')) {
+      browserName = 'Safari';
+      browserVersion = userAgent.match(/version\/([\d.]+)/)?.[1] || '';
+      osVersion = userAgent.match(/OS ([\d_]+)/i)?.[1]?.replace(/_/g, '.') || 'Unknown';
+      osName = 'Mac OS';
+    }
   }
 
-  const platform = userAgent || '';
-  if (platform.includes('mac')) {
-    osName = 'Mac OS';
-  } else if (platform.includes('win')) {
-    osName = 'Windows';
-    osVersion = userAgent.match(/Windows NT ([\d.]+)/)?.[1] || 'Unknown';
-  } else if (/iphone|ipad|ipod/.test(userAgent)) {
+  // now for mobile devices  based browsers like
+
+  if (/iphone|ipad|ipod/.test(userAgent)) {
     osName = 'iOS';
     osVersion = userAgent.match(/OS ([\d_]+)/i)?.[1]?.replace(/_/g, '.') || 'Unknown';
   } else if (platform.includes('android')) {


### PR DESCRIPTION
<!-- Note: Please ensure your PR is targeting the `develop` branch -->
<!-- Describe what this PR is for in the title. -->
<!-- `*` denotes required fields -->

## Purpose of the PR\*

<!-- Describe the purpose of the PR. -->
#170  
Extension is not tracking weather the user is using other device other than Browser like (Samsung mobile, Iphone , etc )

## Priority\*

- [ ] High: This PR needs to be merged first, before other tasks.
- [x] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Changes\*
1. Implemented more checks in order to detect touch devices and smaller screen devices (`detect-emulation.utils.ts`)
2. Using all the logic with respect to `navigator.userAgent` in file `user-agent.utils.ts` 

All the Why's and How's are discussed in this discussion #208 

## How to check the feature / Video Demo 
Here the notion doc link ( uploaded video there as can it exceeds the size) : https://www.notion.so/vishalk988/Device-not-located-20f8a65a48518082ade7ecd08320fa05?source=copy_link

## Reference

<!-- Any helpful information for understanding the PR. -->
-  small viewport &  Touch event spoofing : https://stackoverflow.com/questions/28544445/how-to-detect-device-mode-emulation
