### PR TITLE
fix: included sandbox-api url to restricted URLs

### DIFF
--- a/chrome-extension/src/utils/manage-records.util.ts
+++ b/chrome-extension/src/utils/manage-records.util.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { deepRedactSensitiveInfo } from '@extension/shared';
 
-const restricted = ['https://api.briehq.com']; // 'extend.iife',  'kbmbnelnoppneadncmmkfikbcgmilbao'  Note: it blocks the logs
+const restricted = ['https://api.briehq.com', 'https://sandbox-api.briehq.com']; // 'extend.iife',  'kbmbnelnoppneadncmmkfikbcgmilbao'  Note: it blocks the logs
 const invalidRecord = (entity: string) => restricted.some(word => entity.includes(word));
 
 const tabRecordsMap = new Map<number, Map<string, any>>();


### PR DESCRIPTION
<!-- Note: Please ensure your PR is targeting the `develop` branch -->
<!-- Describe what this PR is for in the title. -->
<!-- `*` denotes required fields -->

## Purpose of the PR\*

fixes #32 

<!-- Describe the purpose of the PR. -->

It simply adds the sandbox API url to the extension restrictions.

- I tested the issue in a production build (`mozilla firefox addon`) didn't seem to work, though during development, the requests seems to by pass. Adding it in `restrictions`  prevented this.
- I'm not sure if this is the best fix, or if using a regex would be better. But using a regex over the domain might make the extension unusable when accessed from that domain (e.g., brie in this case).

## Priority\*

- [ ] High: This PR needs to be merged first, before other tasks.
- [x] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.


