### PR TITLE
Limits enabled when in development mode 

### DIFF
--- a/pages/popup/src/components/capture/screenshot-button.capture.tsx
+++ b/pages/popup/src/components/capture/screenshot-button.capture.tsx
@@ -41,11 +41,19 @@ export const CaptureScreenshotGroup = () => {
 
   const [activeTab, setActiveTab] = useState({ id: null, url: '' });
   const [currentActiveTab, setCurrentActiveTab] = useState<number>();
+  const isCaptureScreenshotDisabled = useMemo(() => {
+    // Skip limit check in dev/sandbox environments
+    if (process.env.NAME === '[Sandbox] Brie') {
+      return false;
+    }
 
-  const isCaptureScreenshotDisabled = useMemo(
-    () => totalSlicesCreatedToday > 10 && user?.fields?.authMethod === 'GUEST',
-    [totalSlicesCreatedToday, user?.fields?.authMethod],
-  );
+    // Only disable if:
+    // 1. User is a guest
+    // 2. Has hit the daily limit
+    return (
+      user?.fields?.authMethod === 'GUEST' && totalSlicesCreatedToday > 10 && Boolean(activeTab.id) // Check if there's an active capture tab
+    );
+  }, [totalSlicesCreatedToday, user?.fields?.authMethod, activeTab.id]);
 
   const isCaptureActive = useMemo(() => ['capturing', 'unsaved'].includes(captureState), [captureState]);
 


### PR DESCRIPTION
<!-- Note: Please ensure your PR is targeting the `develop` branch -->
<!-- Describe what this PR is for in the title. -->
<!-- `*` denotes required fields -->

## Purpose of the PR\*

<!-- Describe the purpose of the PR. -->
- Fixes an issue where guest users are blocked from capturing slices even when there are no active slices. The capture buttons are incorrectly disabled after reaching the guest slice limit, which results in unnecessary user lockouts.
- Also when contributor is in `development ` mode then it's enabled all-time

## Priority\*

- [ ] High: This PR needs to be merged first, before other tasks.
- [x] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Changes\*

## How to check the feature

<!-- Describe how to check the feature in detail -->
<!-- If there are any visual changes, please attach a screenshot for easy identification. -->

## Reference

<!-- Any helpful information for understanding the PR. -->
