### PR TITLE
bug(#223): fixed darkmode is affecting webpages 

### DIFF
--- a/packages/storage/lib/impl/theme.storage.ts
+++ b/packages/storage/lib/impl/theme.storage.ts
@@ -13,10 +13,20 @@ const storage = createStorage<Theme>('theme-storage-key', 'light', {
 });
 
 const applyTheme = (theme: Theme) => {
-  if (theme === 'dark') {
-    document.documentElement.classList.add('dark');
-  } else {
-    document.documentElement.classList.add('light');
+  const shadowHost = document.querySelector('#brie-root');
+  // as the main is rendered by index.html so now targeting that
+  const isPopup = window.location.pathname.includes('index.html');
+
+  // targetingf to only #shadow-root
+  if (shadowHost) {
+    shadowHost.classList.remove('dark', 'light');
+    shadowHost.classList.add(theme);
+  }
+
+  // Apply to popup <html>
+  if (isPopup) {
+    document.documentElement.classList.remove('dark', 'light');
+    document.documentElement.classList.add(theme);
   }
 };
 

--- a/pages/content-ui/src/index.tsx
+++ b/pages/content-ui/src/index.tsx
@@ -37,7 +37,7 @@ if (navigator.userAgent.includes('Firefox')) {
 const currentTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 rootIntoShadow.classList.add(currentTheme);
 
-// Apply the system theme via the storage API (if you need to persist or listen to changes)
+// Apply the system theme via the storage API
 themeStorage.applySystemTheme();
 themeStorage.listenToSystemThemeChanges();
 


### PR DESCRIPTION


<!-- Note: Please ensure your PR is targeting the `develop` branch -->
<!-- Describe what this PR is for in the title. -->
<!-- `*` denotes required fields -->

## Purpose of the PR\*

#223 as discussed in this issue 
- when system-theme is set to dark then and when used Brie extension 
- It changes the theme of the main dom element


<!-- Describe the purpose of the PR. -->

## Priority\*

- [ ] High: This PR needs to be merged first, before other tasks.
- [x] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Changes\*

- It was due to how `next-themes` are applied (they add the classes ) 
- Also I wasn't checked the whole `shadow-root` element for dark theme implementation . 
- Now used a custom `theme-provider.tsx` and wrapped it around the `Content` in `App.tsx` in order to segregate and achieve dark theme to only `shadow-root` div 



## How to check the feature

- Main issue was seen on  "https://www.inuafund.co.ke/login" and " https://www.inuafund.co.ke/" website's navbar when switched to dark-theme 
- Here's the video of the corrected dark-theme implementation ! 
https://youtu.be/EB_9_WfaiCY



## Reference


#223 