### PR TITLE
ci: pin Dependabot to target develop branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,12 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependencies"
+      - "javascript"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

Repo default branch is \`main\`, so Dependabot opens npm PRs against \`main\` by default. PRs #275 and #277 landed there directly (had to be backported via #280). This pins \`target-branch: develop\` so all future dep update PRs go to the right place.

Also adds:
- \`labels: [dependencies, javascript]\` — matches what Dependabot was implicitly adding
- \`open-pull-requests-limit: 10\` — default is 5; we routinely have 5+ open

## Test plan

- [ ] After merge, watch the next scheduled Dependabot run (weekly) — new PRs should target \`develop\`
- [ ] Confirm "Protect main" ruleset is set to **Active** in repo settings (already done by you)