### PR TITLE
fix: remove debug console.log from rewind-player

### DIFF
--- a/pages/content-ui/src/components/recording-view/views/rewind-player.view.tsx
+++ b/pages/content-ui/src/components/recording-view/views/rewind-player.view.tsx
@@ -375,7 +375,6 @@ export const RewindPlayer = ({
     try {
       const meta = typeof replayer.getMeta === 'function' ? replayer.getMeta() : null;
       const t = (meta as any)?.currentTime;
-      console.log('meta', meta);
       if (typeof t === 'number' && Number.isFinite(t)) return t;
     } catch {
       //


### PR DESCRIPTION
Removed a debug console.log statement from rewind-player.view.tsx that was leaving logging artifacts in production. The line console.log(meta, meta) was used during development and is not appropriate for production code.