### PR TITLE
fix(storage): re-narrow chrome.storage values for newer @types/chrome

### DIFF
--- a/packages/storage/lib/base/base.ts
+++ b/packages/storage/lib/base/base.ts
@@ -94,7 +94,10 @@ export const createStorage = <D = string>(key: string, fallback: D, config?: Sto
       return fallback;
     }
 
-    return deserialize(value[key]) ?? fallback;
+    // value[key] is typed `unknown` in newer @types/chrome (chrome.storage can
+    // hold any JSON-serializable value); we always write via `serialize` which
+    // returns string, so re-narrowing here matches what we actually wrote.
+    return deserialize(value[key] as string) ?? fallback;
   };
 
   const _emitChange = () => {
@@ -134,7 +137,7 @@ export const createStorage = <D = string>(key: string, fallback: D, config?: Sto
     // Check if the key we are listening for is in the changes object
     if (changes[key] === undefined) return;
 
-    const valueOrUpdate: ValueOrUpdate<D> = deserialize(changes[key].newValue);
+    const valueOrUpdate: ValueOrUpdate<D> = deserialize(changes[key].newValue as string);
 
     if (cache === valueOrUpdate) return;
 


### PR DESCRIPTION
## Summary

Unblocks dependabot #286 (`@types/chrome 0.0.304 → 0.1.42`), which surfaced two `TS2345` errors in `packages/storage/lib/base/base.ts`:

\`\`\`
lib/base/base.ts(97,24): Argument of type 'unknown' is not assignable to parameter of type 'string'.
lib/base/base.ts(137,57): Argument of type 'unknown' is not assignable to parameter of type 'string'.
\`\`\`

The newer `@types/chrome` types `chrome.storage[area].get()` return values as `{ [key: string]: unknown }` and `chrome.storage.StorageChange.newValue` as `unknown` — reflecting that the API can hold any JSON-serializable value, not just strings.

Our `serialize` function always returns `string` (see `StorageConfig.serialization.serialize` signature), so we know what we wrote. Re-narrowing with a local `as string` cast matches what we actually wrote, doesn't change the public API, and is a no-op on the current `@types/chrome` 0.0.304.

## Test plan

- [x] Local `pnpm type-check` in `packages/storage` passes with current @types/chrome.
- [ ] CI green here on develop.
- [ ] After this lands, trigger `@dependabot recreate` on #286; build should go green.