### PR TITLE
ci(e2e): skip on dependabot PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,6 +11,9 @@ permissions:
 
 jobs:
   chrome:
+    # Dependabot PRs run without repository secrets, so .env.production is
+    # never created and the test suite fails on install. Skip cleanly.
+    if: github.actor != 'dependabot[bot]'
     name: E2E tests for Chrome
     runs-on: ubuntu-latest
     steps:
@@ -24,6 +27,7 @@ jobs:
       - run: pnpm e2e
 
   firefox:
+    if: github.actor != 'dependabot[bot]'
     name: E2E tests for Firefox
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Stops the structural red E2E check we kept hitting on dependabot bumps. Their `GITHUB_TOKEN` runs without repository secrets, so `copy_env` can't materialize `.env.production` and `pnpm install` aborts before tests can run — pure noise that has nothing to do with the dep being bumped.

Adds `if: github.actor != 'dependabot[bot]'` to both Chrome and Firefox jobs.

Human-authored PRs (including manual force-pushes onto dependabot branches) still run the full E2E suite.

## Companion fix
This pairs with option (a) — landing the develop-side `dependabot.yml` (already with `target-branch: develop`) onto main so dependabot stops opening PRs against main in the first place. That will land via the next develop→main release.

## Test plan
- [ ] Next dependabot PR: E2E shows as **skipped**, not failed.
- [ ] Any human-authored PR: E2E still runs.