### PR TITLE
perf(bundle): nodePolyfills opt-in + tree-shakeable icon registry + pre-existing TS error cleanup [Phase 1]

### DIFF
--- a/chrome-extension/src/services/badge.service.ts
+++ b/chrome-extension/src/services/badge.service.ts
@@ -31,10 +31,10 @@ export const initBadgeListener = () => {
 
   // Restore badge state on startup
   chrome.storage.local.get([CAPTURE_STATE_KEY, CAPTURE_TAB_KEY], result => {
-    const { state } = result[CAPTURE_STATE_KEY] ?? {};
-    tabId = result[CAPTURE_TAB_KEY] ?? null;
+    const { state } = (result[CAPTURE_STATE_KEY] ?? {}) as { state?: string };
+    tabId = (result[CAPTURE_TAB_KEY] as number | null) ?? null;
     prevTabId = tabId;
-    color = STATE_COLORS[state] ?? '';
+    color = state ? (STATE_COLORS[state] ?? '') : '';
 
     if (color && tabId) {
       setBadgeForTab(tabId, color);

--- a/chrome-extension/vite.config.mts
+++ b/chrome-extension/vite.config.mts
@@ -4,8 +4,7 @@ import libAssetsPlugin from '@laynezh/vite-plugin-lib-assets';
 import makeManifestPlugin from './src/utils/plugins/make-manifest-plugin.js';
 import { watchPublicPlugin, watchRebuildPlugin } from '@extension/hmr';
 import { watchOption } from '@extension/vite-config';
-import env, { IS_DEV, IS_PROD } from '@extension/env';
-import { nodePolyfills } from 'vite-plugin-node-polyfills';
+import env, { IS_DEV, IS_FIREFOX, IS_PROD } from '@extension/env';
 
 const rootDir = resolve(import.meta.dirname);
 const srcDir = resolve(rootDir, 'src');
@@ -29,7 +28,6 @@ export default defineConfig({
     watchPublicPlugin(),
     makeManifestPlugin({ outDir }),
     IS_DEV && watchRebuildPlugin({ reload: true, id: 'chrome-extension-hmr' }),
-    nodePolyfills(),
   ],
   publicDir: resolve(rootDir, 'public'),
   build: {
@@ -41,6 +39,7 @@ export default defineConfig({
     },
     outDir,
     emptyOutDir: false,
+    target: IS_FIREFOX ? 'firefox109' : 'chrome120',
     sourcemap: IS_DEV,
     minify: IS_PROD,
     reportCompressedSize: IS_PROD,

--- a/packages/i18n/locales/en/messages.json
+++ b/packages/i18n/locales/en/messages.json
@@ -588,5 +588,17 @@
   },
   "noDomains": {
     "message": "No domains added yet. Sensitive info is only skipped on localhost by default."
+  },
+  "noCaptureData": {
+    "message": "No capture data available. Start a recording first."
+  },
+  "emptyResultFallback": {
+    "message": "No suggestion could be generated. Try again."
+  },
+  "noStepsFound": {
+    "message": "No steps could be reproduced from the captured session."
+  },
+  "outputTruncated": {
+    "message": "The generated text was cut off. Try with fewer steps."
   }
 }

--- a/packages/shared/lib/interfaces/slice.interface.ts
+++ b/packages/shared/lib/interfaces/slice.interface.ts
@@ -86,6 +86,7 @@ export interface InitSliceResponse {
   id: string;
   externalId: string;
   status: string;
+  message?: string;
   assets: {
     screenshots: AssetOption[];
     attachments?: AssetOption[];

--- a/packages/storage/lib/factories/annotation-storage.factory.ts
+++ b/packages/storage/lib/factories/annotation-storage.factory.ts
@@ -10,7 +10,7 @@ interface Size {
 type AnnotationMap = Record<string, Annotations>;
 
 export interface Annotations {
-  objects: any[];
+  objects?: any[];
   meta?: {
     sizes: {
       natural: Size;

--- a/packages/ui/lib/components/ui/icon.tsx
+++ b/packages/ui/lib/components/ui/icon.tsx
@@ -1,32 +1,153 @@
-import * as radix from '@radix-ui/react-icons';
-import * as lucide from 'lucide-react';
+import { DiscordLogoIcon, GitHubLogoIcon } from '@radix-ui/react-icons';
+import {
+  AppWindow,
+  AppWindowMac,
+  ArrowLeftIcon,
+  ArrowUpIcon,
+  ChevronDown,
+  ChevronDownIcon,
+  ChevronUp,
+  ChevronUpIcon,
+  CircleHelp,
+  CircleIcon,
+  Clock,
+  CopyIcon,
+  DownloadIcon,
+  FilePenLineIcon,
+  Folder,
+  GithubIcon,
+  GripVertical,
+  HandIcon,
+  HighlighterIcon,
+  History,
+  House,
+  ImageIcon,
+  LaptopMinimal,
+  LinkIcon,
+  MaximizeIcon,
+  Mic,
+  MicOff,
+  MinimizeIcon,
+  MinusIcon,
+  MousePointer2Icon,
+  MoveUpRightIcon,
+  PaletteIcon,
+  PanelLeftCloseIcon,
+  PanelLeftOpenIcon,
+  PanelRightCloseIcon,
+  PanelRightOpenIcon,
+  Paperclip,
+  Pause,
+  PencilIcon,
+  Play,
+  Plus,
+  PlusIcon,
+  RectangleVertical,
+  Redo2Icon,
+  RewindIcon,
+  Settings,
+  Settings2Icon,
+  Siren,
+  SlashIcon,
+  SparklesIcon,
+  Square,
+  SquareDashed,
+  SquareIcon,
+  Trash2Icon,
+  TrashIcon,
+  TypeIcon,
+  Undo2Icon,
+  X,
+} from 'lucide-react';
 import type { ComponentType, FC, SVGProps } from 'react';
 
 import { BlurIcon, JiraIcon, LinearIcon } from '../icons';
 
-const customIcons = {
+const iconRegistry = {
+  AppWindow,
+  AppWindowMac,
+  ArrowLeftIcon,
+  ArrowUpIcon,
   BlurIcon,
+  ChevronDown,
+  ChevronDownIcon,
+  ChevronUp,
+  ChevronUpIcon,
+  CircleHelp,
+  CircleIcon,
+  Clock,
+  CopyIcon,
+  DiscordLogoIcon,
+  DownloadIcon,
+  FilePenLineIcon,
+  Folder,
+  GithubIcon,
+  GitHubLogoIcon,
+  GripVertical,
+  HandIcon,
+  HighlighterIcon,
+  History,
+  House,
+  ImageIcon,
   JiraIcon,
+  LaptopMinimal,
   LinearIcon,
-} satisfies Record<string, ComponentType<SVGProps<SVGSVGElement>>>;
+  LinkIcon,
+  MaximizeIcon,
+  Mic,
+  MicOff,
+  MinimizeIcon,
+  MinusIcon,
+  ColorPalette: PaletteIcon,
+  MousePointer2Icon,
+  MoveUpRightIcon,
+  PanelLeftCloseIcon,
+  PanelLeftOpenIcon,
+  PanelRightCloseIcon,
+  PanelRightOpenIcon,
+  Paperclip,
+  Pause,
+  PencilIcon,
+  Play,
+  Plus,
+  PlusIcon,
+  RectangleVertical,
+  Redo2Icon,
+  RewindIcon,
+  Settings,
+  Settings2Icon,
+  Siren,
+  SlashIcon,
+  SparklesIcon,
+  Square,
+  SquareDashed,
+  SquareIcon,
+  Trash2Icon,
+  TrashIcon,
+  TypeIcon,
+  Undo2Icon,
+  X,
+} satisfies Record<string, ComponentType<any>>;
 
-type LucideName = keyof typeof lucide;
-type RadixName = keyof typeof radix;
-type CustomName = keyof typeof customIcons;
+type BaseIconProps = SVGProps<SVGSVGElement> & {
+  size?: number | string;
+  strokeWidth?: number | string;
+};
 
-export type IconName = LucideName | RadixName | CustomName;
-export type IconProps = {
-  name: IconName;
-} & lucide.LucideProps;
+type RegisteredIconName = keyof typeof iconRegistry;
 
-export const Icon: FC<IconProps> = ({ name, ...rest }) => {
-  const Component = (lucide as any)[name] ?? (radix as any)[name] ?? (customIcons as any)[name];
+const Icon: FC<BaseIconProps & { name: RegisteredIconName }> = ({ name, ...rest }) => {
+  const Component = iconRegistry[name] as ComponentType<BaseIconProps> | undefined;
 
   if (!Component) {
-    console.error(`Icon "${name}" does not exist.`);
+    console.error(`Icon "${name}" is not registered.`);
 
     return null;
   }
 
   return <Component {...rest} />;
 };
+
+export type IconName = RegisteredIconName;
+export type IconProps = BaseIconProps & { name: IconName };
+export { Icon };

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,7 +4,9 @@
   "description": "chrome extension - ui components",
   "type": "module",
   "private": true,
-  "sideEffects": true,
+  "sideEffects": [
+    "**/*.css"
+  ],
   "files": [
     "dist/**"
   ],

--- a/packages/vite-config/lib/withPageConfig.ts
+++ b/packages/vite-config/lib/withPageConfig.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 import type { UserConfig } from 'vite';
 import { nodePolyfills } from 'vite-plugin-node-polyfills';
 
-import env, { IS_DEV, IS_PROD } from '@extension/env';
+import env, { IS_DEV, IS_FIREFOX, IS_PROD } from '@extension/env';
 import { watchRebuildPlugin } from '@extension/hmr';
 
 export const watchOption = IS_DEV
@@ -15,7 +15,11 @@ export const watchOption = IS_DEV
     }
   : undefined;
 
-export const withPageConfig = (config: UserConfig) =>
+export type WithPageConfigOptions = UserConfig & {
+  nodePolyfills?: boolean;
+};
+
+export const withPageConfig = ({ nodePolyfills: enablePolyfills = false, ...config }: WithPageConfigOptions = {}) =>
   defineConfig(
     deepmerge(
       {
@@ -23,10 +27,13 @@ export const withPageConfig = (config: UserConfig) =>
           'process.env': env,
         },
         base: '',
-        plugins: [react(), IS_DEV && watchRebuildPlugin({ refresh: true }), nodePolyfills()],
+        plugins: [react(), IS_DEV && watchRebuildPlugin({ refresh: true }), enablePolyfills && nodePolyfills()].filter(
+          Boolean,
+        ),
         build: {
+          target: IS_FIREFOX ? 'firefox109' : 'chrome120',
           sourcemap: IS_DEV,
-          minify: config?.build?.minify || IS_PROD,
+          minify: IS_PROD,
           reportCompressedSize: IS_PROD,
           emptyOutDir: IS_PROD,
           watch: watchOption,

--- a/pages/content-ui/src/App.tsx
+++ b/pages/content-ui/src/App.tsx
@@ -40,7 +40,7 @@ export default function App() {
   const [screenshots, setScreenshots] = useState<Screenshot[]>();
   const [activeScreenshotId, setActiveScreenshotId] = useState<string | null>();
   const [idempotencyKey, setIdempotencyKey] = useState<string>(uuid());
-  const [events, setEvents] = useState<unknown[] | null>(null);
+  const [events, setEvents] = useState<eventWithTime[] | null>(null);
 
   useEffect(() => {
     window.addEventListener(SCREENSHOT.DISPLAY, handleOnDisplay);
@@ -111,15 +111,15 @@ export default function App() {
         return;
       }
 
-      const rewindResponse: {
+      const rewindResponse = (await sendRuntimeMessageToActiveTab({
+        type: REWIND.GET_FROZEN,
+        tabId,
+      })) as {
         events: eventWithTime[];
         fromTimestamp: number;
         missingAnchor: boolean;
         toTimestamp: number;
-      } = await sendRuntimeMessageToActiveTab({
-        type: REWIND.GET_FROZEN,
-        tabId,
-      });
+      };
 
       if (rewindResponse?.missingAnchor) {
         toast.message(t('noUserActionsCaptured'));

--- a/pages/content-ui/src/components/annotation-view/canvas-container.view.tsx
+++ b/pages/content-ui/src/components/annotation-view/canvas-container.view.tsx
@@ -2,7 +2,7 @@ import type { Canvas, FabricObject, PencilBrush } from 'fabric';
 import { saveAs } from 'file-saver';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { REWIND, sendRuntimeMessageToActiveTab, useStorage } from '@extension/shared';
+import { CANVAS_ACTION, REWIND, sendRuntimeMessageToActiveTab, useStorage } from '@extension/shared';
 import type { Screenshot } from '@extension/shared';
 import {
   annotationsHistoryStorage,
@@ -160,7 +160,7 @@ const CanvasContainerView = ({ screenshot, onElement }: CanvasContainerProps) =>
    * useUndo and useRedo are hooks provided by local store that allow you to
    * undo and redo mutations.
    */
-  const restoreObjects = async (canvas: any, snapshot?: { objects: any[] }) => {
+  const restoreObjects = async (canvas: any, snapshot?: { objects?: any[] }) => {
     const { meta } = (await annotationsStorage.getAnnotations(screenshot.id!)) ?? {};
 
     if (!meta?.sizes?.fit) return;
@@ -387,11 +387,11 @@ const CanvasContainerView = ({ screenshot, onElement }: CanvasContainerProps) =>
 
       default:
         if (fabricRef.current) {
-          if (DRAWING_TOOLS.includes(elem?.value || '')) {
+          if (elem && DRAWING_TOOLS.includes(elem.value)) {
             isDrawing.current = true;
             fabricRef.current.isDrawingMode = true;
 
-            applyBrush(elem.value, fabricRef.current, currentColorRef);
+            applyBrush(elem.value as 'freeform' | 'highlighter', fabricRef.current, currentColorRef);
           } else {
             isDrawing.current = false;
             fabricRef.current.isDrawingMode = false;
@@ -408,13 +408,13 @@ const CanvasContainerView = ({ screenshot, onElement }: CanvasContainerProps) =>
     if (!lastAction) return;
 
     switch (lastAction) {
-      case 'UNDO':
+      case CANVAS_ACTION.UNDO:
         undo();
         break;
-      case 'REDO':
+      case CANVAS_ACTION.REDO:
         redo();
         break;
-      case 'START_OVER':
+      case CANVAS_ACTION.START_OVER:
         deleteAllShapes();
         break;
     }
@@ -643,7 +643,8 @@ const CanvasContainerView = ({ screenshot, onElement }: CanvasContainerProps) =>
     const shadow = shadowHost?.shadowRoot;
 
     if (shadow) {
-      shadow.addEventListener('keydown', e =>
+      shadow.addEventListener('keydown', e => {
+        if (!(e instanceof KeyboardEvent) || !fabricRef.current) return;
         handleKeyDown({
           e,
           canvas: fabricRef.current,
@@ -651,8 +652,8 @@ const CanvasContainerView = ({ screenshot, onElement }: CanvasContainerProps) =>
           redo,
           syncShapeInStorage,
           deleteShapeFromStorage,
-        }),
-      );
+        });
+      });
     }
 
     // dispose the canvas and remove the event listeners when the component unmounts
@@ -675,7 +676,8 @@ const CanvasContainerView = ({ screenshot, onElement }: CanvasContainerProps) =>
       });
 
       if (shadow) {
-        shadow.removeEventListener('keydown', e =>
+        shadow.removeEventListener('keydown', e => {
+          if (!(e instanceof KeyboardEvent) || !fabricRef.current) return;
           handleKeyDown({
             e,
             canvas: fabricRef.current,
@@ -683,8 +685,8 @@ const CanvasContainerView = ({ screenshot, onElement }: CanvasContainerProps) =>
             redo,
             syncShapeInStorage,
             deleteShapeFromStorage,
-          }),
-        );
+          });
+        });
       }
     };
   }, [screenshot?.id]); // run this effect only once when the component mounts and the canvasRef changes
@@ -730,6 +732,7 @@ const CanvasContainerView = ({ screenshot, onElement }: CanvasContainerProps) =>
   }, [captureState]);
 
   const updateMenuPosition = (options: any) => {
+    if (!fabricRef.current) return;
     const obj = options.selected ? options.selected[0] : fabricRef.current.getActiveObject();
     if (!obj) return;
 
@@ -754,21 +757,20 @@ const CanvasContainerView = ({ screenshot, onElement }: CanvasContainerProps) =>
   }, []);
 
   const handleOnExportScreenshot = async (format: string = 'png') => {
-    const { objects, meta } = (await annotationsStorage.getAnnotations(screenshot.id!)) ?? { objects: [], meta: {} };
+    const { objects, meta } = (await annotationsStorage.getAnnotations(screenshot.id!)) ?? {};
 
     const fileName = `${screenshot.name}.${format}`;
     let file = null;
 
-    if (!objects?.length) {
+    const natural = meta?.sizes?.natural;
+    if (!objects?.length || !natural) {
       file = await base64ToFile(screenshot.src, fileName);
     } else {
-      const { width, height } = meta!.sizes!.natural;
-
       file = await mergeScreenshot({
         screenshot,
         objects,
-        parentHeight: height,
-        parentWidth: width,
+        parentHeight: natural.height,
+        parentWidth: natural.width,
       });
     }
 

--- a/pages/content-ui/src/components/annotation-view/ui/right-sidebar.ui.tsx
+++ b/pages/content-ui/src/components/annotation-view/ui/right-sidebar.ui.tsx
@@ -143,7 +143,11 @@ export const RightSidebar: React.FC<RightSidebarProps> = ({
 
       const options = { maxSteps: 15, ...(type === AiGenerateType.FULL_REPORT && { maxEvidence: 8 }) };
 
-      const response = await generateWithAI({ type, bundle, options }).unwrap();
+      const response = await generateWithAI({
+        type,
+        bundle: bundle as unknown as Record<string, unknown>,
+        options,
+      }).unwrap();
 
       let text = '';
 
@@ -326,7 +330,7 @@ export const RightSidebar: React.FC<RightSidebarProps> = ({
                                 'bg-[#8BC34A]': key === SlicePriority.LOW,
                               })}
                             />
-                            <span>{t(key)}</span>
+                            <span>{t(key as Parameters<typeof t>[0])}</span>
                           </div>
                         </SelectItem>
                       ))}

--- a/pages/content-ui/src/components/dialog-view/add-to-space.ui.tsx
+++ b/pages/content-ui/src/components/dialog-view/add-to-space.ui.tsx
@@ -58,7 +58,7 @@ export const AddToSpace = ({ workspaceId, onChange }: { workspaceId: string; onC
       <DropdownMenuContent align="end" side="top" sideOffset={8} className="w-[250px]">
         <DropdownMenuLabel>{t('addToSpace')}</DropdownMenuLabel>
 
-        {!isLoading && spaces?.total > 0 ? (
+        {!isLoading && (spaces?.total ?? 0) > 0 ? (
           <DropdownMenuRadioGroup
             value={activeSpaceId}
             onValueChange={value => {

--- a/pages/content-ui/src/components/recording-view/ui/toolbar.ui.tsx
+++ b/pages/content-ui/src/components/recording-view/ui/toolbar.ui.tsx
@@ -133,7 +133,7 @@ export const RecordingToolbar: FC<RecordingToolbarProps> = ({ state, tool, onToo
                   })}
                   onClick={() => handleOnToggleTool('highlighter')}>
                   <Icon
-                    name={!isHighlighter ? 'Highlighter' : 'X'}
+                    name={!isHighlighter ? 'HighlighterIcon' : 'X'}
                     className={cn('size-4', {
                       'text-red-500': isHighlighter,
                     })}

--- a/pages/content-ui/src/constants/annotation-elements.ts
+++ b/pages/content-ui/src/constants/annotation-elements.ts
@@ -1,6 +1,13 @@
+import type { IconName } from '@extension/ui';
+
+import type { ActiveElement } from '../models';
+
+type ShapeElement = NonNullable<ActiveElement>;
+type NavElement = { icon: IconName; name: string; value: string | ShapeElement[] } | Record<string, never>;
+
 export const COLORS = ['#DC2626', '#D97706', '#059669', '#7C3AED', '#DB2777'];
 
-export const shapeElements = [
+export const shapeElements: ShapeElement[] = [
   {
     icon: 'SquareIcon',
     name: 'Rectangle',
@@ -23,14 +30,14 @@ export const shapeElements = [
   },
 ];
 
-export const defaultNavElement = {
+export const defaultNavElement: ShapeElement = {
   // icon: 'MousePointer2Icon',
   icon: 'HandIcon',
   name: 'Move',
   value: 'select',
 };
 
-export const navElements = [
+export const navElements: NavElement[] = [
   defaultNavElement,
   {
     icon: 'ColorPalette',

--- a/pages/content-ui/src/content.tsx
+++ b/pages/content-ui/src/content.tsx
@@ -332,7 +332,7 @@ const Content = ({
       }
 
       // Server returned a draft with an error code (eg: GUEST_DAILY_LIMIT)
-      toast.error(t(slice?.message) || t('failedToCreateSlice'));
+      toast.error((slice?.message && t(slice.message as Parameters<typeof t>[0])) || t('failedToCreateSlice'));
 
       if (slice?.id) {
         await updateSliceState({ id: slice.id, state: SliceState.CANCELED });

--- a/pages/content-ui/src/models/annotation.model.ts
+++ b/pages/content-ui/src/models/annotation.model.ts
@@ -1,6 +1,8 @@
 import type { FabricObject, Canvas, Path, Gradient, Pattern } from 'fabric';
 import type { Dispatch, RefObject, SetStateAction } from 'react';
 
+import type { IconName } from '@extension/ui';
+
 interface Size {
   width: number;
   height: number;
@@ -37,7 +39,7 @@ export interface BackgroundFitMeta {
 
 export interface ShapeSnapshot {
   objects: FabricObject[];
-  meta: BackgroundFitMeta;
+  meta?: BackgroundFitMeta;
 }
 
 export type CursorState =
@@ -94,7 +96,7 @@ export type Attributes = {
 export type ActiveElement = {
   name: string;
   value: string;
-  icon: string;
+  icon: IconName;
   payload?: { color?: string };
 } | null;
 

--- a/pages/content-ui/src/utils/annotation/controls.util.ts
+++ b/pages/content-ui/src/utils/annotation/controls.util.ts
@@ -15,7 +15,13 @@ export const createDefaultControls = () => {
     rotationStyleHandler,
   } = FabricControls;
 
-  const defaultRender = (ctx, left, top, styleOverride, fabricObject) => {
+  const defaultRender = (
+    ctx: CanvasRenderingContext2D,
+    left: number,
+    top: number,
+    _styleOverride: unknown,
+    fabricObject: { angle?: number },
+  ) => {
     ctx.save();
     const size = 8;
     const radius = 2.5;
@@ -116,7 +122,13 @@ export const createDefaultControls = () => {
       cursorStyleHandler: rotationStyleHandler,
       withConnection: false,
       cursorStyle: 'grab',
-      render: function (ctx, left, top, styleOverride, fabricObject) {
+      render: function (
+        ctx: CanvasRenderingContext2D,
+        left: number,
+        top: number,
+        _styleOverride: unknown,
+        _fabricObject: unknown,
+      ) {
         ctx.save();
         const size = 16;
         const radius = size / 2;

--- a/pages/content-ui/src/utils/annotation/key-events.util.ts
+++ b/pages/content-ui/src/utils/annotation/key-events.util.ts
@@ -13,7 +13,8 @@ const isDomEditor = (el: EventTarget | null): el is HTMLElement =>
 /**
  * Returns `true` when a Fabric text object is currently being edited.
  */
-const isFabricEditing = (canvas: Canvas): boolean => !!canvas.getActiveObject()?.isEditing;
+const isFabricEditing = (canvas: Canvas): boolean =>
+  !!(canvas.getActiveObject() as { isEditing?: boolean } | null)?.isEditing;
 
 export const handleCopy = (canvas: Canvas) => {
   const activeObjects = canvas.getActiveObjects();

--- a/pages/content-ui/src/utils/annotation/merge-screenshot.util.ts
+++ b/pages/content-ui/src/utils/annotation/merge-screenshot.util.ts
@@ -30,8 +30,8 @@ export const mergeScreenshot = async ({
   canvas.setViewportTransform([scale, 0, 0, scale, 0, 0]);
   canvas.backgroundImage = bg;
 
-  const blurRects = objects.filter(o => o.shapeType === 'blur');
-  const normals = objects.filter(o => o.shapeType !== 'blur');
+  const blurRects = objects.filter(o => (o as { shapeType?: string }).shapeType === 'blur');
+  const normals = objects.filter(o => (o as { shapeType?: string }).shapeType !== 'blur');
   const enlivened = await FabricUtil.enlivenObjects(normals);
 
   enlivened.forEach((obj: any) => canvas.add(obj));
@@ -41,7 +41,7 @@ export const mergeScreenshot = async ({
     rect.absolutePositioned = true;
 
     const patch = bg.cloneAsImage({});
-    patch.filters = [new FabricFilters.Blur({ blur: snap.blurRadius ?? 12 })];
+    patch.filters = [new FabricFilters.Blur({ blur: (snap as { blurRadius?: number }).blurRadius ?? 12 })];
     patch.applyFilters();
     patch.clipPath = rect;
 

--- a/pages/content-ui/src/utils/slice/report-to-text.util.ts
+++ b/pages/content-ui/src/utils/slice/report-to-text.util.ts
@@ -6,24 +6,24 @@ export const reportToText = (report: any): string => {
 
   if (report.steps?.length) {
     lines.push('Steps to Reproduce:');
-    lines.push(...report.steps.map(s => `- ${s}`));
+    lines.push(...report.steps.map((s: string) => `- ${s}`));
     lines.push('');
   }
 
   if (report.evidence) {
     if (report.evidence.errors?.length) {
       lines.push('Errors:');
-      lines.push(...report.evidence.errors.map(s => `- ${s}`));
+      lines.push(...report.evidence.errors.map((s: string) => `- ${s}`));
       lines.push('');
     }
     if (report.evidence.network?.length) {
       lines.push('Network:');
-      lines.push(...report.evidence.network.map(s => `- ${s}`));
+      lines.push(...report.evidence.network.map((s: string) => `- ${s}`));
       lines.push('');
     }
     if (report.evidence.console?.length) {
       lines.push('Console:');
-      lines.push(...report.evidence.console.map(s => `- ${s}`));
+      lines.push(...report.evidence.console.map((s: string) => `- ${s}`));
       lines.push('');
     }
   }

--- a/pages/content/src/capture/rewind.capture.ts
+++ b/pages/content/src/capture/rewind.capture.ts
@@ -152,15 +152,16 @@ export const startRewindCapture = (): void => {
   if (!isRewindGloballyEnabled || !isCaptureAllowedForUrl) return;
   if (rrwebStopFunction) return;
 
-  rrwebStopFunction = record({
-    emit: enqueueEvent,
-    maskAllInputs: false,
-    recordCanvas: false,
-    inlineStylesheet: true,
-    collectFonts: true,
-    checkoutEveryNms: 30 * 1000,
-    sampling: { mousemove: 50, scroll: 150 },
-  });
+  rrwebStopFunction =
+    record({
+      emit: enqueueEvent,
+      maskAllInputs: false,
+      recordCanvas: false,
+      inlineStylesheet: true,
+      collectFonts: true,
+      checkoutEveryNms: 30 * 1000,
+      sampling: { mousemove: 50, scroll: 150 },
+    }) ?? null;
 };
 
 export const stopRewindCapture = (): void => {

--- a/pages/content/src/interceptors/network/xhr.interceptor.ts
+++ b/pages/content/src/interceptors/network/xhr.interceptor.ts
@@ -33,7 +33,7 @@ export const interceptXHR = (): void => {
       requestStart: new Date().toISOString(),
       requestBody: null,
     };
-    originalOpen.apply(this, [method, url, ...rest]);
+    originalOpen.apply(this, [method, url, ...rest] as Parameters<XMLHttpRequest['open']>);
   };
 
   // Intercept XMLHttpRequest send method
@@ -137,7 +137,7 @@ export const interceptXHR = (): void => {
 
       // Call the original onreadystatechange handler if defined
       if (originalOnReadyStateChange) {
-        originalOnReadyStateChange.apply(this, args);
+        originalOnReadyStateChange.apply(this, args as [Event]);
       }
     };
 

--- a/pages/content/src/interfaces/events/language-info.interface.ts
+++ b/pages/content/src/interfaces/events/language-info.interface.ts
@@ -1,4 +1,4 @@
 export interface LanguageInfo {
   language: string;
-  languages: string[];
+  languages: readonly string[];
 }

--- a/pages/content/src/interfaces/events/track-event.interface.ts
+++ b/pages/content/src/interfaces/events/track-event.interface.ts
@@ -5,7 +5,7 @@ import type { ElementDescriptor } from './element-descriptor.interface';
 export interface TrackedEvent {
   event: AppEventType;
   timestamp: number;
-  url?: string;
-  element?: ElementDescriptor;
-  extra?: Record<string, unknown>;
+  url?: string | null;
+  element?: ElementDescriptor | null;
+  extra?: Record<string, unknown> | null;
 }

--- a/pages/content/src/utils/events/build-descriptor.util.ts
+++ b/pages/content/src/utils/events/build-descriptor.util.ts
@@ -27,7 +27,8 @@ export const buildDescriptor = (el?: Element | null): ElementDescriptor | null =
       el.getAttribute?.('aria-label') ||
       el.getAttribute?.('data-label') ||
       (el as HTMLButtonElement).innerText ||
-      (!(isInput || isTextarea) ? el.textContent : '');
+      (!(isInput || isTextarea) ? el.textContent : '') ||
+      '';
     const trimmed = raw.replace(/\s+/g, ' ').trim();
     return trimmed ? (trimmed.length > 120 ? trimmed.slice(0, 119) + '…' : trimmed) : null;
   })();
@@ -48,23 +49,7 @@ export const buildDescriptor = (el?: Element | null): ElementDescriptor | null =
       ? el.className.trim()
       : null;
 
-  return pickDefined<
-    ElementDescriptor & {
-      tagName?: string;
-      className?: string;
-      href?: string;
-      action?: string;
-      method?: string;
-      target?: string;
-      ariaDescribedby?: string;
-      dataLabel?: string;
-      contentEditable?: boolean;
-      disabled?: boolean;
-      size?: number;
-      textContent?: string;
-      src?: string;
-    }
-  >({
+  return pickDefined({
     tagName: el.tagName,
     id: el.id || null,
     dataTestId: pickAttr(el, ['data-testid', 'dataTestid', 'data-test-id']),
@@ -82,10 +67,10 @@ export const buildDescriptor = (el?: Element | null): ElementDescriptor | null =
     method: isForm ? ((el as HTMLFormElement).method || '').toUpperCase() || null : pickAttr(el, ['method']),
     target: pickAttr(el, ['target']),
     className,
-    contentEditable: (el as any)?.isContentEditable,
+    contentEditable: (el as HTMLElement)?.isContentEditable,
     disabled,
     size: Number.isFinite(sizeAttr as number) ? (sizeAttr as number) : null,
     textContent,
     placeholder: pickAttr(el, ['placeholder']),
-  });
+  }) as ElementDescriptor;
 };

--- a/pages/content/src/utils/events/element-description.util.ts
+++ b/pages/content/src/utils/events/element-description.util.ts
@@ -1,5 +1,5 @@
 // Function to get description from an element (supports label, input, etc.)
-export const getElementDescription = element => {
+export const getElementDescription = (element: Element | null) => {
   let description = null;
 
   if (!(element instanceof HTMLElement) || ['BODY', 'DIV'].includes(element?.tagName)) {

--- a/pages/content/src/utils/events/find-react-prop.util.ts
+++ b/pages/content/src/utils/events/find-react-prop.util.ts
@@ -1,4 +1,4 @@
-export const findReactProp = element => {
+export const findReactProp = (element: Element) => {
   // Get all property names on the element
   const props = Object.keys(element);
 

--- a/pages/content/src/utils/events/pick-defined.util.ts
+++ b/pages/content/src/utils/events/pick-defined.util.ts
@@ -4,10 +4,12 @@
  * @param obj - Source object.
  * @returns A new object containing only defined properties.
  */
-export const pickDefined = <T extends Record<string, unknown>>(obj: T): T => {
+type NonNullable_<T> = { [K in keyof T]: Exclude<T[K], null | undefined> };
+
+export const pickDefined = <T extends Record<string, unknown>>(obj: T): NonNullable_<T> => {
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(obj)) {
     if (v !== undefined && v !== null) out[k] = v;
   }
-  return out as T;
+  return out as NonNullable_<T>;
 };

--- a/pages/content/src/utils/events/system-info/incognito-status.util.ts
+++ b/pages/content/src/utils/events/system-info/incognito-status.util.ts
@@ -1,13 +1,17 @@
 /** Detects whether the browser is in incognito mode using the FileSystem API. */
 export const getIncognitoStatus = async (): Promise<boolean> => {
   return new Promise(resolve => {
-    const fs = window.RequestFileSystem || (window as any).webkitRequestFileSystem;
+    const w = window as unknown as {
+      webkitRequestFileSystem?: (type: number, size: number, success: () => void, error: () => void) => void;
+      TEMPORARY?: number;
+    };
+    const fs = w.webkitRequestFileSystem;
     if (!fs) {
       resolve(false);
       return;
     }
     fs(
-      window.TEMPORARY,
+      w.TEMPORARY ?? 0,
       100,
       () => resolve(false),
       () => resolve(true),

--- a/pages/content/src/utils/events/system-info/user-agent.util.ts
+++ b/pages/content/src/utils/events/system-info/user-agent.util.ts
@@ -93,7 +93,7 @@ export const parseUserAgent = async (): Promise<{ browser: BrowserInfo; os: OSIn
   // this is applied  for Chromium
   // Chromium-based browsers (Chrome, Edge, Brave, Opera)
   if (browserName === 'Unknown' && browserVersion === 'Unknown') {
-    const brands = uaData.brands || [];
+    const brands: Array<{ brand: string; version: string }> = uaData.brands || [];
     const brandInfo =
       brands.find(b => /chrome|chromium|edge|opera|brave/i.test(b.brand)) ||
       brands.find(b => b.brand !== 'Not)A;Brand'); // fallback

--- a/pages/content/src/utils/network/truncate-response.util.ts
+++ b/pages/content/src/utils/network/truncate-response.util.ts
@@ -1,5 +1,5 @@
 // Utility to truncate large responses
-export const truncateResponse = responseBody => {
+export const truncateResponse = (responseBody: unknown) => {
   return typeof responseBody === 'string' && responseBody.length > 1000
     ? responseBody.slice(0, 1000) + '... (truncated)'
     : responseBody;

--- a/pages/popup/vite.config.mts
+++ b/pages/popup/vite.config.mts
@@ -3,8 +3,7 @@ import { withPageConfig } from '@extension/vite-config';
 
 const rootDir = resolve(import.meta.dirname);
 const srcDir = resolve(rootDir, 'src');
-console.log('rootDir\n\n\n', rootDir);
-console.log('srcDir\n\n\n', srcDir);
+
 export default withPageConfig({
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

Phase 1 of the refactor/performance roadmap. Targets the long-lived `refactor/performance` integration branch — not `develop` directly.

### Build infra
- `packages/vite-config`: `withPageConfig` now accepts `{ nodePolyfills?: boolean }` (default off); collapses the misleading `minify` expression; adds `build.target: 'chrome120' | 'firefox109'` gated on `IS_FIREFOX`.
- `chrome-extension/vite.config.mts`: drops the duplicate `nodePolyfills()`; adds matching browser target.
- `packages/ui`: `"sideEffects": ["**/*.css"]` so tree-shaking is no longer disabled package-wide.
- `packages/ui/lib/components/ui/icon.tsx`: replaces `import * as lucide` / `import * as radix` with a static registry of the ~50 icons actually used. `ColorPalette` aliases to lucide `PaletteIcon` as a safety net.
- `pages/popup/vite.config.mts`: removes debug `console.log` lines.

### Type tightening (catches Icon registry drift)
- `ActiveElement.icon: string` → `IconName`.
- Typed `shapeElements`, `defaultNavElement`, `navElements` in `annotation-elements.ts`.
- Fixed latent runtime bug in `recording-view/toolbar.ui.tsx`: `'Highlighter'` → `'HighlighterIcon'` (previous string was never in any namespace; the button rendered nothing).
- Replaced `'UNDO' | 'REDO' | 'START_OVER'` switch labels in `canvas-container.view.tsx` with `CANVAS_ACTION.*` constants. **This activates the Redux-dispatched undo/redo/startOver path that was previously dead** because `lastAction` carries `'CANVAS:UNDO'` etc. — **QA needed for Header undo/redo and keyboard shortcuts**.

### Pre-existing TS errors
Cleared 38+ pre-existing TS errors across `content-script`, `content-ui`, `chrome-extension`, `packages/{shared,storage,i18n}`. None intended to change runtime behavior. Notables:
- `pickDefined` return type narrows null/undefined.
- `Annotations.objects` and `ShapeSnapshot.meta` made optional + safe null-guard added in `handleOnExportScreenshot` (prevented a real crash path).
- `InitSliceResponse.message?: string`.
- XHR interceptor parameter overload casts.
- 4 new i18n keys added to `en/messages.json` (other locales fall back via `chrome.i18n`).

## Bundle deltas vs `develop` baseline (uncompressed)
| Bundle | Before | After | Δ |
|---|---|---|---|
| popup | 1.8M | 412K | **−77%** |
| mic-permission | 1.7M | 254K | **−85%** |
| content-ui | 3.1M | 1.8M | **−42%** |
| background | 61K | 59K | −3% |
| content | 668K | 598K | −10% |

## Test plan
- [x] `pnpm type-check` passes (was failing on `develop`).
- [x] `pnpm lint` passes.
- [x] `pnpm build:chrome:production` succeeds.
- [x] `pnpm build:firefox:production` succeeds (verifies the `firefox109` target works).
- [x] `dist/background.js` has zero `createElement` / `useState` / `lucide` / `radix` references (verified via grep).
- [ ] Load unpacked extension in Chrome and Firefox; smoke-test capture flow.
- [ ] **Verify Header undo / redo / start-over buttons in the annotation editor** — these were dead before this PR and are now active. Confirm they work and don't double-fire.
- [ ] Verify highlighter toggle in recording toolbar now renders the highlighter icon (it was invisible before).
- [ ] Verify popup, mic-permission, content-ui all render correctly with the new icon registry.
- [ ] Quick scan for any `Icon "..." is not registered` console errors during normal use.