### PR TITLE
perf(sw): reduce always-on cost on the webRequest hot path [Phase 2]

### DIFF
--- a/chrome-extension/manifest.ts
+++ b/chrome-extension/manifest.ts
@@ -47,16 +47,16 @@ const manifest = {
   },
   content_scripts: [
     {
-      matches: ['http://*/*', 'https://*/*', '<all_urls>'],
+      matches: ['<all_urls>'],
       js: ['content/index.iife.js'],
       run_at: 'document_start',
     },
     {
-      matches: ['http://*/*', 'https://*/*', '<all_urls>'],
+      matches: ['<all_urls>'],
       js: ['content-ui/index.iife.js'],
     },
     {
-      matches: ['http://*/*', 'https://*/*', '<all_urls>'],
+      matches: ['<all_urls>'],
       css: ['content.css'],
     },
   ],

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -1,3 +1,4 @@
+import type { WebRequest } from 'webextension-polyfill';
 import { tabs, contextMenus, runtime, webRequest, webNavigation } from 'webextension-polyfill';
 
 import {
@@ -21,15 +22,37 @@ runtime.onInstalled.addListener(handleOnInstalled);
 contextMenus.onClicked.addListener(handleOnContextMenuClicked);
 
 /**
+ * Skip high-volume, low-signal types (images, fonts, media, ping, csp_report, other) — these
+ * compounded the cost of every redaction pass without producing useful bug-capture data. Scripts
+ * and stylesheets are kept so broken-asset 4xx/5xx errors are still reported.
+ *
  * @todo
- * there is an scenario when tabId is -1,
+ * there is a scenario when tabId is -1,
  * but we know the requestId and we can use it to populate the right request data
  *
  * related to all 3 web req states
  */
-webRequest.onBeforeRequest.addListener(handleOnBeforeRequest, { urls: ['<all_urls>'] }, ['requestBody']);
-webRequest.onBeforeSendHeaders.addListener(handleOnBeforeSendHeaders, { urls: ['<all_urls>'] }, ['requestHeaders']);
-webRequest.onCompleted.addListener(handleOnCompleted, { urls: ['<all_urls>'] });
+const TRACKED_REQUEST_TYPES: WebRequest.ResourceType[] = [
+  'main_frame',
+  'sub_frame',
+  'script',
+  'stylesheet',
+  'xmlhttprequest',
+  'websocket',
+];
+
+webRequest.onBeforeRequest.addListener(handleOnBeforeRequest, { urls: ['<all_urls>'], types: TRACKED_REQUEST_TYPES }, [
+  'requestBody',
+]);
+webRequest.onBeforeSendHeaders.addListener(
+  handleOnBeforeSendHeaders,
+  { urls: ['<all_urls>'], types: TRACKED_REQUEST_TYPES },
+  ['requestHeaders'],
+);
+webRequest.onCompleted.addListener(handleOnCompleted, {
+  urls: ['<all_urls>'],
+  types: TRACKED_REQUEST_TYPES,
+});
 webNavigation.onCommitted.addListener(handleOnCommitted);
 
 initBadgeListener();

--- a/chrome-extension/src/services/web-request.service.ts
+++ b/chrome-extension/src/services/web-request.service.ts
@@ -1,50 +1,47 @@
 import type { WebRequest } from 'webextension-polyfill';
 
-import { safeStructuredClone } from '@extension/shared';
-
+import type { Record } from '@src/types';
 import { addOrMergeRecords } from '@src/utils';
 
+// Chrome passes plain serializable objects to webRequest handlers, so we can spread directly
+// without an extra structuredClone deep-copy on every event. The cast handles the polyfill type's
+// `bytes: unknown` shape (which is `ArrayBuffer` in practice for webRequest payloads).
 export const handleOnBeforeRequest = (request: WebRequest.OnBeforeRequestDetailsType) => {
   addOrMergeRecords(request.tabId, {
     recordType: 'network',
     source: 'background',
-    ...safeStructuredClone(request),
-  });
+    ...request,
+  } as unknown as Record);
 };
 
 export const handleOnBeforeSendHeaders = (request: WebRequest.OnBeforeSendHeadersDetailsType) => {
   addOrMergeRecords(request.tabId, {
     recordType: 'network',
     source: 'background',
-    ...safeStructuredClone(request),
-  });
+    ...request,
+  } as unknown as Record);
 };
 
 export const handleOnCompleted = (request: WebRequest.OnCompletedDetailsType) => {
-  const clonedRequest = safeStructuredClone(request);
-
-  addOrMergeRecords(clonedRequest.tabId, {
+  addOrMergeRecords(request.tabId, {
     recordType: 'network',
     source: 'background',
-    ...clonedRequest,
-  });
+    ...request,
+  } as unknown as Record);
 
-  if (clonedRequest.statusCode >= 400) {
-    addOrMergeRecords(clonedRequest.tabId, {
+  if (request.statusCode >= 400) {
+    addOrMergeRecords(request.tabId, {
       timestamp: Date.now(),
       type: 'log',
       recordType: 'console',
       source: 'background',
       method: 'error',
-      args: [
-        `[${clonedRequest.type}] ${clonedRequest.method} ${clonedRequest.url} responded with status ${clonedRequest.statusCode}`,
-        clonedRequest,
-      ],
+      args: [`[${request.type}] ${request.method} ${request.url} responded with status ${request.statusCode}`, request],
       stackTrace: {
         parsed: 'interceptFetch',
         raw: '',
       },
-      url: clonedRequest.url,
-    });
+      url: request.url,
+    } as unknown as Record);
   }
 };

--- a/chrome-extension/src/utils/manage-records.util.ts
+++ b/chrome-extension/src/utils/manage-records.util.ts
@@ -1,5 +1,4 @@
 import { v4 as uuidv4 } from 'uuid';
-import { tabs } from 'webextension-polyfill';
 
 import { deepRedactSensitiveInfo } from '@extension/shared';
 import { domainSkipListStorage } from '@extension/storage';
@@ -7,6 +6,24 @@ import { domainSkipListStorage } from '@extension/storage';
 import type { Record } from '@src/types';
 
 import { decodeRequestBody } from './decode-request-body.util';
+
+// Cache the skip list in memory. Refreshed via storage.subscribe so the cost is paid once per change,
+// not once per webRequest event (which fires hundreds of times per page load).
+let skipDomainsCache: string[] = [];
+
+const refreshSkipDomainsFromSnapshot = () => {
+  skipDomainsCache = domainSkipListStorage.getSnapshot() ?? [];
+};
+
+// Prime the cache once, then keep it in sync via the storage subscriber (cheap, no async).
+void domainSkipListStorage.get().then(value => {
+  skipDomainsCache = value ?? [];
+});
+domainSkipListStorage.subscribe(refreshSkipDomainsFromSnapshot);
+
+// Cap per-tab record count so a long browsing session can't grow the SW heap without bound.
+const MAX_RECORDS_PER_TAB = 5_000;
+const MAX_URL_MAP_PER_TAB = 1_000;
 
 const RESTRICTED = [
   'https://api.briehq.com',
@@ -54,19 +71,33 @@ export const addOrMergeRecords = async (tabId: number, record: Record): Promise<
     return;
   }
 
-  const [tab] = await tabs.query({ active: true, lastFocusedWindow: true });
-  const tabUrl = tab?.url || record?.url;
-  const skipDomains = await domainSkipListStorage.get();
+  // Use the in-memory skip list cache populated by domainSkipListStorage.subscribe.
+  // First call during SW boot may race the initial load and read [] — acceptable: redaction
+  // simply runs as if no domains were skip-listed for the first few requests.
+  const skipDomains = skipDomainsCache;
+  const tabUrl = record?.url || record?.pageUrl;
 
   if (!tabRecordsMap.has(tabId)) {
     tabRecordsMap.set(tabId, new Map());
   }
 
   const recordsMap = tabRecordsMap.get(tabId)!;
+
   const uuid = uuidv4();
+
+  // Drop the oldest entry once we know we'd otherwise grow the map (i.e. this is a brand-new
+  // insertion, not a merge into an existing recordKey). Eviction is performed inline at each
+  // insert site below so we never delete a key we're about to merge into.
+  const evictOldestIfFull = () => {
+    if (recordsMap.size >= MAX_RECORDS_PER_TAB) {
+      const oldestKey = recordsMap.keys().next().value;
+      if (oldestKey !== undefined) recordsMap.delete(oldestKey);
+    }
+  };
 
   try {
     if (record.recordType !== 'network') {
+      evictOldestIfFull();
       recordsMap.set(uuid, { uuid, ...deepRedactSensitiveInfo(record, tabUrl, skipDomains) });
       return;
     }
@@ -82,6 +113,11 @@ export const addOrMergeRecords = async (tabId: number, record: Record): Promise<
     let finalRequestId = requestId;
 
     if (type === 'xmlhttprequest' && requestId) {
+      // Bound the per-tab URL→requestId map (Map preserves insertion order, so this drops the oldest entry).
+      if (urlMap.size >= MAX_URL_MAP_PER_TAB) {
+        const oldestKey = urlMap.keys().next().value;
+        if (oldestKey !== undefined) urlMap.delete(oldestKey);
+      }
       urlMap.set(url, requestId);
     }
 
@@ -130,6 +166,7 @@ export const addOrMergeRecords = async (tabId: number, record: Record): Promise<
     };
 
     if (!recordsMap.has(recordKey)) {
+      evictOldestIfFull();
       recordsMap.set(recordKey, { uuid, url, ...redactedRecord });
       return;
     }

--- a/chrome-extension/src/utils/rewind.util.ts
+++ b/chrome-extension/src/utils/rewind.util.ts
@@ -373,7 +373,8 @@ const ingestRewindEvents = async (tabId: number, events: unknown[]): Promise<voi
     return;
   }
 
-  await flushTabToStorage(tabId);
+  // Below threshold: let the scheduled timer coalesce the write.
+  // Previously this path awaited flushTabToStorage AND scheduled a flush, defeating the debounce.
   scheduleFlushForTab(tabId);
 };
 

--- a/packages/shared/lib/constants/sensitive-keywords.constants.ts
+++ b/packages/shared/lib/constants/sensitive-keywords.constants.ts
@@ -1,4 +1,19 @@
-export const STRONG_KEYS = [
+// Pre-compile a single case-insensitive regex per list — keyMatches runs on every key of every
+// network record, so the per-call `new RegExp(...)` cost was multiplied across thousands of calls.
+const buildListRegex = (list: string[]): RegExp =>
+  new RegExp(`(^|[^a-z0-9])(?:${list.map(s => s.replace(/_/g, '[_-]?')).join('|')})([^a-z0-9]|$)`, 'i');
+
+const compiledListRegexes = new WeakMap<string[], RegExp>();
+const getListRegex = (list: string[]): RegExp => {
+  let re = compiledListRegexes.get(list);
+  if (!re) {
+    re = buildListRegex(list);
+    compiledListRegexes.set(list, re);
+  }
+  return re;
+};
+
+const STRONG_KEYS = [
   'okta',
   'authorization',
   'oai-sc',
@@ -50,10 +65,10 @@ export const STRONG_KEYS = [
 ];
 
 // Explicitly DO NOT redact these by name
-export const EXEMPT_KEYS = ['username', 'user_name', 'email', 'e-mail', 'login', 'user', 'user_id', 'userid'];
+const EXEMPT_KEYS = ['username', 'user_name', 'email', 'e-mail', 'login', 'user', 'user_id', 'userid'];
 
 // Non-sensitive/date-ish by default
-export const NON_SENSITIVE_KEYS = [
+const NON_SENSITIVE_KEYS = [
   'date',
   'start_date',
   'end_date',
@@ -66,6 +81,6 @@ export const NON_SENSITIVE_KEYS = [
   'expiration_date',
 ];
 
-// Compile case-insensitive boundary-aware matchers
-export const keyMatches = (k: string | undefined | null, list: string[]) =>
-  !!k && list.some(s => new RegExp(`(^|[^a-z0-9])${s.replace(/_/g, '[_-]?')}([^a-z0-9]|$)`, 'i').test(k));
+const keyMatches = (k: string | undefined | null, list: string[]) => !!k && getListRegex(list).test(k);
+
+export { STRONG_KEYS, EXEMPT_KEYS, NON_SENSITIVE_KEYS, keyMatches };

--- a/packages/shared/lib/utils/redact-sensitive-info.util.ts
+++ b/packages/shared/lib/utils/redact-sensitive-info.util.ts
@@ -10,8 +10,6 @@ import {
 
 type Strength = 'strong' | 'allow' | 'unknown';
 
-const redactSkipCache = new Map<string, boolean>();
-
 const classifyField = (ctx: {
   key?: string;
   name?: string;
@@ -177,7 +175,6 @@ const isSkipDomain = (url?: string, skipDomains?: string[]): boolean => {
  * Deeply redacts sensitive information from an input structure.
  * Automatically skips redaction in non-production environments or
  * when the URL matches a domain in the user-configured skip list.
- * Uses cache when `uuid` is available on the object.
  *
  * @param input - Any value (object, array, string, etc.) to redact.
  * @param url - Optional URL to determine if redaction should apply (e.g. non-prod).
@@ -185,25 +182,6 @@ const isSkipDomain = (url?: string, skipDomains?: string[]): boolean => {
  * @returns Redacted copy of the input.
  */
 export const deepRedactSensitiveInfo = (input: any, url?: string, skipDomains?: string[]): any => {
-  const nonProd = isNonProduction(url);
-  const domainSkipped = isSkipDomain(url, skipDomains);
-  const shouldSkip = nonProd || domainSkipped;
-  const cacheKey =
-    input && typeof input === 'object' && input.uuid ? `${input.uuid}::${shouldSkip ? 'skip' : 'prod'}` : undefined;
-
-  let shouldSkipRedaction = false;
-
-  if (cacheKey) {
-    const cached = redactSkipCache.get(cacheKey);
-    if (cached !== undefined) {
-      shouldSkipRedaction = cached;
-    } else {
-      shouldSkipRedaction = shouldSkip;
-      redactSkipCache.set(cacheKey, shouldSkipRedaction);
-    }
-  } else {
-    shouldSkipRedaction = shouldSkip;
-  }
-
+  const shouldSkipRedaction = isNonProduction(url) || isSkipDomain(url, skipDomains);
   return deepRedactInternal(input, shouldSkipRedaction);
 };


### PR DESCRIPTION
## Summary

Phase 2 of the refactor/performance roadmap. The MV3 service worker observes every request on every tab; this cuts the per-event cost and stops the unbounded SW heap growth.

### Changes
- **manage-records.util.ts**:
  - Cache `domainSkipListStorage` in memory via `storage.subscribe`.
  - Drop the per-event `chrome.tabs.query` IPC round-trip; use `record.url || record.pageUrl` (also more correct for background-tab requests).
  - Cap `tabRecordsMap` at 5k entries/tab and `tabUrlToRequestId` at 1k/tab with insertion-order eviction. Eviction fires only on brand-new inserts so merges never lose data.
- **background/index.ts**: add `WebRequest.ResourceType` filter to all 3 listeners. Drops images, fonts, media, ping, csp_report. Keeps scripts and stylesheets so broken-asset 4xx/5xx errors stay visible.
- **web-request.service.ts**: drop `safeStructuredClone()` from all 3 handlers.
- **packages/shared/sensitive-keywords.constants.ts**: pre-compile a single regex per list, cached in `WeakMap`. Was `new RegExp(...)` per call.
- **packages/shared/redact-sensitive-info.util.ts**: delete `redactSkipCache` (keyed by always-unique UUID → 0 hits, unbounded growth).
- **rewind.util.ts**: remove the unconditional `await flushTabToStorage(tabId)` on every sub-threshold batch; debounced timer now coalesces writes as intended.
- **manifest.ts**: collapse `content_scripts.matches` to just `['<all_urls>']`.

## Test plan
- [x] `pnpm type-check` passes.
- [x] `pnpm build:chrome:production` succeeds, `dist/background.js` = 59K.
- [ ] Load unpacked extension in Chrome; smoke-test capture flow end-to-end on a complex SPA (e.g. Linear).
- [ ] Verify that 4xx/5xx XHR/fetch and broken-script/stylesheet errors are still surfaced in captured records.
- [ ] Open DevTools on SW, run a 1-min browsing session across 5+ tabs; SW heap should stay flat (not grow proportionally to request count).
- [ ] Confirm sensitive value redaction still works on a captured record (e.g., `password`, `Authorization` headers).
- [ ] Quickly toggle the domain skip list in popup settings; confirm cache picks up the new value within ~1 event.