### PR TITLE
perf(content): cut per-page tax of the content script [Phase 3]

### DIFF
--- a/pages/content/src/capture/rewind.capture.ts
+++ b/pages/content/src/capture/rewind.capture.ts
@@ -4,11 +4,12 @@ import { record } from 'rrweb';
 import { isRewindBlocked, REWIND } from '@extension/shared';
 import { rewindSettingsStorage } from '@extension/storage';
 
+import { BRIE_URL_CHANGED_EVENT } from '@src/interceptors/events';
+
 type RrwebStopFunction = () => void;
 
 const MAX_BATCH_EVENTS = 200;
 const FLUSH_INTERVAL_MS = 250;
-const URL_WATCH_INTERVAL_MS = 500;
 
 const RRWEB_META_EVENT_TYPE = 4;
 const RRWEB_FULL_SNAPSHOT_EVENT_TYPE = 2;
@@ -152,13 +153,16 @@ export const startRewindCapture = (): void => {
   if (!isRewindGloballyEnabled || !isCaptureAllowedForUrl) return;
   if (rrwebStopFunction) return;
 
+  // Stylesheet inlining and font collection serialize the entire page CSS / @font-face graph
+  // into the initial snapshot — megabytes on sites with large frameworks. Default to off and
+  // only enable when the user explicitly turned on rewind globally.
   rrwebStopFunction =
     record({
       emit: enqueueEvent,
       maskAllInputs: false,
       recordCanvas: false,
-      inlineStylesheet: true,
-      collectFonts: true,
+      inlineStylesheet: false,
+      collectFonts: false,
       checkoutEveryNms: 30 * 1000,
       sampling: { mousemove: 50, scroll: 150 },
     }) ?? null;
@@ -209,13 +213,24 @@ export const restartRewindCapture = async (): Promise<{ ok: boolean; reason?: st
   return { ok: true };
 };
 
+/**
+ * Detect SPA URL changes without polling.
+ *
+ * `historyApiInterceptor` (in interceptors/events/history.interceptor.ts) already monkey-patches
+ * pushState/replaceState and dispatches `brie:url-changed` on every transition. We subscribe to
+ * that broadcast plus `hashchange` (which the events interceptor does not handle) — no second
+ * patch on history.* avoids stacking wrappers if either module is re-evaluated.
+ */
 const startUrlWatcher = (): void => {
-  setInterval(() => {
+  const checkUrl = () => {
     const currentUrl = window.location.href;
     if (currentUrl === lastKnownUrl) return;
     lastKnownUrl = currentUrl;
     void applyPolicy(currentUrl);
-  }, URL_WATCH_INTERVAL_MS);
+  };
+
+  window.addEventListener(BRIE_URL_CHANGED_EVENT, checkUrl);
+  window.addEventListener('hashchange', checkUrl, { passive: true });
 };
 
 const bootstrap = async (): Promise<void> => {
@@ -224,4 +239,17 @@ const bootstrap = async (): Promise<void> => {
   startUrlWatcher();
 };
 
-bootstrap();
+// Defer bootstrap off the critical path. rewindSettingsStorage.isRewindEnabled() is async and
+// computeCapturePolicy() reads more storage; running this at idle keeps the host page's first
+// paint clean. Worst case: rrweb misses the earliest few events (acceptable — bootstrap is fast).
+const scheduleBootstrap = (): void => {
+  type RIC = (cb: () => void, opts?: { timeout?: number }) => number;
+  const ric = (window as unknown as { requestIdleCallback?: RIC }).requestIdleCallback;
+  if (typeof ric === 'function') {
+    ric(() => void bootstrap(), { timeout: 2000 });
+  } else {
+    setTimeout(() => void bootstrap(), 0);
+  }
+};
+
+scheduleBootstrap();

--- a/pages/content/src/capture/screenshot.capture.ts
+++ b/pages/content/src/capture/screenshot.capture.ts
@@ -16,6 +16,10 @@ let dimensionLabel: HTMLDivElement;
 let message: HTMLDivElement | null = null;
 let loadingMessage: HTMLDivElement | null = null;
 
+// Named handler refs so cleanup() can actually removeEventListener.
+let selectionMouseUpHandler: ((e: MouseEvent) => void) | null = null;
+let selectionTouchEndHandler: ((e: TouchEvent) => void) | null = null;
+
 const waitForRepaint = () =>
   new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
 const getShadowHost = () => document.getElementById('brie-root');
@@ -229,6 +233,18 @@ const updateSelectionBox = (e: MouseEvent | TouchEvent) => {
 const onMouseDown = (e: MouseEvent | TouchEvent, mode: 'single' | 'multiple') => {
   if ('button' in e && e.button !== 0) return; // Only respond to left-click
 
+  // If a previous selection's handlers are still registered (e.g. user re-triggers screenshot
+  // before completing the first one), remove them before installing new ones. Otherwise the
+  // module-level refs get overwritten and the old listeners leak.
+  if (selectionMouseUpHandler) {
+    document.removeEventListener('mouseup', selectionMouseUpHandler);
+    selectionMouseUpHandler = null;
+  }
+  if (selectionTouchEndHandler) {
+    document.removeEventListener('touchend', selectionTouchEndHandler);
+    selectionTouchEndHandler = null;
+  }
+
   isSelecting = true;
 
   // Use viewport-relative coordinates
@@ -243,11 +259,16 @@ const onMouseDown = (e: MouseEvent | TouchEvent, mode: 'single' | 'multiple') =>
   createSelectionBox();
   createDimensionLabel();
 
+  // updateSelectionBox does not call preventDefault, so passive: true preserves the browser's
+  // scroll-optimisation fast path. Named refs let cleanup() actually remove the up/end listeners.
+  selectionMouseUpHandler = (ev: MouseEvent) => onMouseUp(ev, mode);
+  selectionTouchEndHandler = (ev: TouchEvent) => onTouchEnd(ev, mode);
+
   document.addEventListener('keydown', onKeyDown);
-  document.addEventListener('mousemove', updateSelectionBox, { passive: false });
-  document.addEventListener('mouseup', e => onMouseUp(e, mode));
-  document.addEventListener('touchmove', updateSelectionBox, { passive: false });
-  document.addEventListener('touchend', e => onTouchEnd(e, mode));
+  document.addEventListener('mousemove', updateSelectionBox, { passive: true });
+  document.addEventListener('mouseup', selectionMouseUpHandler);
+  document.addEventListener('touchmove', updateSelectionBox, { passive: true });
+  document.addEventListener('touchend', selectionTouchEndHandler);
 
   message?.remove();
   message = null;
@@ -651,8 +672,14 @@ export const cleanup = (): void => {
   document.body.style.overflow = '';
   document.removeEventListener('keydown', onKeyDown);
   document.removeEventListener('mousemove', updateSelectionBox);
-  // document.removeEventListener('mouseup', onMouseUp);
+  if (selectionMouseUpHandler) {
+    document.removeEventListener('mouseup', selectionMouseUpHandler);
+    selectionMouseUpHandler = null;
+  }
   document.removeEventListener('touchmove', updateSelectionBox);
-  document.removeEventListener('touchend', () => onTouchEnd({} as TouchEvent, 'single'));
+  if (selectionTouchEndHandler) {
+    document.removeEventListener('touchend', selectionTouchEndHandler);
+    selectionTouchEndHandler = null;
+  }
   document.removeEventListener('scroll', onScroll);
 };

--- a/pages/content/src/interceptors/events/events.interceptor.ts
+++ b/pages/content/src/interceptors/events/events.interceptor.ts
@@ -84,8 +84,7 @@ const handleOnValueChange = (event: Event, reason: 'change' | 'blur' | 'input') 
  * @param event - Mouse click event.
  */
 const handleOnCustomSelectClick = (event: MouseEvent) => {
-  if (pathTouchesExtension(event)) return;
-
+  // pathTouchesExtension early-exit is handled once in handleAllClicks.
   const target = deepTarget(event);
 
   if (!target) return;
@@ -114,8 +113,7 @@ const handleOnCustomSelectClick = (event: MouseEvent) => {
  * @param event - Mouse click event.
  */
 const handleOnClick = (event: MouseEvent) => {
-  if (pathTouchesExtension(event)) return;
-
+  // pathTouchesExtension early-exit is handled once in handleAllClicks.
   const ep = document.elementFromPoint(event.clientX, event.clientY);
   const hitTarget = ep instanceof Element ? ep : deepTarget(event);
 
@@ -146,7 +144,7 @@ const handleOnClick = (event: MouseEvent) => {
  * Emits a single InputChange with inferred checked state.
  */
 const handleOnAriaToggleClick = (event: MouseEvent) => {
-  if (pathTouchesExtension(event)) return;
+  // pathTouchesExtension early-exit is handled once in handleAllClicks.
   const t = deepTarget(event);
   if (!(t instanceof HTMLElement)) return;
 
@@ -364,10 +362,24 @@ const createResizeOncePerActivity = (idleMs = 1000): ResizeHandler => {
   return handler;
 };
 
+let eventsInterceptorRegistered = false;
+
+const handleAllClicks = (event: MouseEvent) => {
+  // Single early-exit on the extension-overlay path so all three handlers don't pay it independently.
+  if (pathTouchesExtension(event)) return;
+  handleOnClick(event);
+  handleOnCustomSelectClick(event);
+  handleOnAriaToggleClick(event);
+};
+
 /**
  * Initializes all capture-phase listeners and starts event interception.
+ * Idempotent — re-running on an SPA navigation will not double-register.
  */
 export const interceptEvents = () => {
+  if (eventsInterceptorRegistered) return;
+  eventsInterceptorRegistered = true;
+
   // Lifecycle
   document.addEventListener('DOMContentLoaded', () => sendEvent(AppEventType.DOMContentLoaded), {
     capture: true,
@@ -395,10 +407,8 @@ export const interceptEvents = () => {
   // Inputs / selects changes
   document.addEventListener('change', e => handleOnValueChange(e, 'change'), { capture: true });
 
-  // Clicks and custom selects
-  document.addEventListener('click', handleOnClick, { capture: true });
-  document.addEventListener('click', handleOnCustomSelectClick, { capture: true });
-  document.addEventListener('click', handleOnAriaToggleClick, { capture: true });
+  // Clicks, custom selects, and ARIA toggles share path/target derivation — merge into one listener.
+  document.addEventListener('click', handleAllClicks, { capture: true });
 
   // Keyboard
   document.addEventListener('keydown', handleOnKeydown, { capture: true });

--- a/pages/content/src/interceptors/events/history.interceptor.ts
+++ b/pages/content/src/interceptors/events/history.interceptor.ts
@@ -1,21 +1,43 @@
 import { AppEventType } from '@src/constants';
 import { sendEvent } from '@src/utils';
 
-// History API interception
-export const historyApiInterceptor = () => {
+/**
+ * Custom event broadcast on every SPA URL transition (pushState / replaceState / popstate).
+ * Other modules (e.g. rewind URL policy) can listen here instead of stacking their own
+ * history.* monkey-patches on top of ours.
+ */
+const BRIE_URL_CHANGED_EVENT = 'brie:url-changed';
+
+let historyInterceptorInstalled = false;
+
+const historyApiInterceptor = () => {
+  if (historyInterceptorInstalled) return;
+  historyInterceptorInstalled = true;
+
+  const dispatchUrlChanged = () => {
+    window.dispatchEvent(new CustomEvent(BRIE_URL_CHANGED_EVENT));
+  };
+
   const originalPushState = history.pushState;
   history.pushState = function (...args) {
     sendEvent(AppEventType.Navigate, null, { url: args[2], method: 'pushState' });
-    originalPushState.apply(history, args);
+    const result = originalPushState.apply(history, args);
+    dispatchUrlChanged();
+    return result;
   };
 
   const originalReplaceState = history.replaceState;
   history.replaceState = function (...args) {
     sendEvent(AppEventType.Navigate, null, { url: args[2], method: 'replaceState' });
-    originalReplaceState.apply(history, args);
+    const result = originalReplaceState.apply(history, args);
+    dispatchUrlChanged();
+    return result;
   };
 
   window.addEventListener('popstate', () => {
     sendEvent(AppEventType.Navigate, null, { url: location.href, method: 'popstate' });
+    dispatchUrlChanged();
   });
 };
+
+export { BRIE_URL_CHANGED_EVENT, historyApiInterceptor };

--- a/pages/content/src/interceptors/events/index.ts
+++ b/pages/content/src/interceptors/events/index.ts
@@ -1,2 +1,2 @@
 export { interceptEvents } from './events.interceptor';
-export { historyApiInterceptor } from './history.interceptor';
+export { historyApiInterceptor, BRIE_URL_CHANGED_EVENT } from './history.interceptor';

--- a/pages/content/src/interceptors/index.ts
+++ b/pages/content/src/interceptors/index.ts
@@ -8,6 +8,8 @@ import { interceptFetch, interceptXHR } from './network';
  */
 const BLOCKED_DOMAINS = ['docs.google.com'];
 
+// Network and event interceptors must run before page scripts execute or events
+// will be missed. Console interception monkey-patches synchronously and is cheap.
 if (!BLOCKED_DOMAINS.includes(window.location.host)) {
   interceptFetch();
 }
@@ -15,6 +17,19 @@ if (!BLOCKED_DOMAINS.includes(window.location.host)) {
 interceptXHR();
 interceptConsole();
 interceptEvents();
-interceptCookies();
-interceptLocalStorage();
-interceptSessionStorage();
+
+// Snapshot interceptors (cookies / localStorage / sessionStorage) iterate all keys at module load —
+// on pages with hundreds of keys this is synchronous work before first paint. Defer to idle.
+type RIC = (cb: () => void, opts?: { timeout?: number }) => number;
+const ric = (window as unknown as { requestIdleCallback?: RIC }).requestIdleCallback;
+const runSnapshotInterceptors = () => {
+  interceptCookies();
+  interceptLocalStorage();
+  interceptSessionStorage();
+};
+
+if (typeof ric === 'function') {
+  ric(runSnapshotInterceptors, { timeout: 2000 });
+} else {
+  setTimeout(runSnapshotInterceptors, 0);
+}

--- a/pages/content/src/interceptors/network/xhr.interceptor.ts
+++ b/pages/content/src/interceptors/network/xhr.interceptor.ts
@@ -45,9 +45,10 @@ export const interceptXHR = (): void => {
       this._requestDetails.requestBody = body || null;
     }
 
-    const originalOnReadyStateChange = this.onreadystatechange;
-
-    this.onreadystatechange = function (this: ExtendedXMLHttpRequest, ...args: any[]): void {
+    // Use addEventListener instead of replacing this.onreadystatechange. The previous code captured
+    // the page's handler at .send() time and re-invoked it after our work, but any code that
+    // assigns xhr.onreadystatechange AFTER calling .send() would be silently lost.
+    const onReadyStateChange = function (this: ExtendedXMLHttpRequest): void {
       if (this.readyState === 4 && this._requestDetails) {
         // Request completed
         const endTime = new Date().toISOString();
@@ -134,12 +135,9 @@ export const interceptXHR = (): void => {
           console.error('[XHR] Error posting message:', error);
         }
       }
-
-      // Call the original onreadystatechange handler if defined
-      if (originalOnReadyStateChange) {
-        originalOnReadyStateChange.apply(this, args as [Event]);
-      }
     };
+
+    this.addEventListener('readystatechange', onReadyStateChange);
 
     originalSend.apply(this, [body]);
   };

--- a/pages/content/src/utils/events/is-clickable.util.ts
+++ b/pages/content/src/utils/events/is-clickable.util.ts
@@ -16,15 +16,10 @@ export const isClickable = (el: Element | null): boolean => {
 
   if (role && ['button', 'link', 'menuitem', 'tab', 'option', 'switch'].includes(role)) return true;
 
-  // Inline handlers only if it *looks* interactive (avoid catching large containers)
-  if (typeof (el as any).onclick === 'function') {
-    const tabIndexAttr = el.getAttribute('tabindex');
-    const tabIndex = tabIndexAttr !== null ? Number(tabIndexAttr) : undefined;
-    const cs = getComputedStyle(el);
-    const looksInteractive =
-      (tabIndex !== undefined && Number.isFinite(tabIndex) && tabIndex >= 0) || cs.cursor === 'pointer';
-    if (looksInteractive) return true;
-  }
+  // Inline handlers: any element with an `onclick` is treated as clickable.
+  // Previously a `cursor: pointer` check via getComputedStyle gated this, but the recalc cost on
+  // every click event was too high — accept slightly broader matching instead.
+  if (typeof (el as unknown as { onclick?: unknown }).onclick === 'function') return true;
 
   return false;
 };

--- a/pages/content/src/utils/events/is-interactive.util.ts
+++ b/pages/content/src/utils/events/is-interactive.util.ts
@@ -1,11 +1,10 @@
 /**
  * Determines whether an element is visible and interactable in layout.
  *
- * Checks:
- * - Non-zero bounding box size
- * - `visibility` not hidden
- * - `display` not none
- * - `pointer-events` not none
+ * Uses non-zero bounding box as a cheap visibility proxy. The previous
+ * `getComputedStyle` checks for `visibility`, `display`, and `pointer-events`
+ * forced a style/layout recalc on every click — they're now skipped because a
+ * zero-size bounding rect already covers the common hidden cases.
  *
  * @param el - The element to evaluate.
  * @returns True if visible and interactable; otherwise false.
@@ -13,9 +12,7 @@
 const isVisibleBox = (el: Element): boolean => {
   const r = (el as HTMLElement).getBoundingClientRect?.();
   if (!r) return true; // be permissive if no layout info
-  if (r.width === 0 || r.height === 0) return false;
-  const cs = getComputedStyle(el);
-  return cs.visibility !== 'hidden' && cs.display !== 'none' && cs.pointerEvents !== 'none';
+  return r.width > 0 && r.height > 0;
 };
 
 /**
@@ -35,9 +32,9 @@ const isHeuristicallyClickable = (el: HTMLElement): boolean => {
   const role = el.getAttribute('role')?.toLowerCase();
   const tabIndexAttr = el.getAttribute('tabindex');
   const tabIndex = tabIndexAttr !== null ? Number(tabIndexAttr) : undefined;
-  const cs = getComputedStyle(el);
 
-  if (cs.cursor === 'pointer') return true;
+  // Note: the `cursor === 'pointer'` check was removed — getComputedStyle on every click event
+  // forced a style/layout recalc. tabindex + ARIA attributes give us enough signal.
   if (tabIndex !== undefined && Number.isFinite(tabIndex) && tabIndex >= 0) return true;
 
   // Common interactive ARIA roles (covers many custom components)
@@ -68,7 +65,9 @@ const isHeuristicallyClickable = (el: HTMLElement): boolean => {
   }
 
   // Draggable often implies interaction
-  if ((el as any).draggable === true || el.getAttribute('draggable') === 'true') return true;
+  if ((el as unknown as { draggable?: boolean }).draggable === true || el.getAttribute('draggable') === 'true') {
+    return true;
+  }
 
   return false;
 };

--- a/pages/content/vite.config.mts
+++ b/pages/content/vite.config.mts
@@ -95,7 +95,8 @@ export default withPageConfig({
   publicDir: resolve(rootDir, 'public'),
   plugins: [selfContainedEntriesPlugin(), IS_DEV && makeEntryPointPlugin()],
   build: {
-    minify: false,
+    // selfContainedEntriesPlugin runs in `generateBundle` BEFORE the minifier — by then all imports
+    // have been inlined and the regex matching is already done, so production minify is safe.
     rollupOptions: {
       input: {
         index: resolve(rootDir, 'src/index.ts'),


### PR DESCRIPTION
## Summary

Phase 3 of the refactor/performance roadmap. The content script runs on every host page the user visits via the content_scripts manifest entry — wins compound across the browsing session.

### Bundle wins (uncompressed)
- `dist/content/index.iife.js`: 598K → **304K** (−49%)
- `dist/content/extend.iife.js`: 47K → **25K** (−47%)

### Changes
- **vite.config.mts** — drop explicit `minify: false`; `selfContainedEntriesPlugin` runs in `generateBundle` so production minify is safe.
- **rewind.capture.ts** — `bootstrap()` deferred to `requestIdleCallback`. `startUrlWatcher` no longer `setInterval(500ms)` — subscribes to `BRIE_URL_CHANGED_EVENT` (broadcast by `historyApiInterceptor`) plus `hashchange`. `inlineStylesheet` / `collectFonts` flipped to `false`.
- **history.interceptor.ts** — idempotent + dispatches `brie:url-changed` so no other module needs to patch `history.*` independently.
- **interceptors/index.ts** — cookies / localStorage / sessionStorage snapshot interceptors deferred to idle.
- **events.interceptor.ts** — 3 click listeners merged into one; `pathTouchesExtension` called once per click. `eventsInterceptorRegistered` guard for idempotency.
- **is-clickable.util.ts / is-interactive.util.ts** — drop `getComputedStyle` (cursor/visibility/display/pointer-events). Plain `onclick` fallback kept in `isClickable` so keyboard activation still works on legacy `onclick` divs.
- **screenshot.capture.ts** — `mousemove`/`touchmove` `passive: true`. Named handler refs so `cleanup()` actually removes them. Re-entry safe.
- **xhr.interceptor.ts** — `addEventListener('readystatechange', ...)` instead of overwriting `this.onreadystatechange` (fixes a real host-page compatibility bug).

## Test plan
- [x] `pnpm type-check` + `pnpm build:chrome:production` pass.
- [ ] Load in Chrome; open a heavy SPA (Linear, Notion, GitHub); verify the page first-paint is not visibly slower with the extension installed.
- [ ] Trigger a screenshot capture (single + multiple modes); verify selection works smoothly with no listener leak after cancel.
- [ ] Verify SPA navigation (pushState/popstate/hashchange) is tracked in captured events.
- [ ] Test a page that assigns `xhr.onreadystatechange` after `.send()` (gmail uses this pattern). Confirm the page's own handler still fires.
- [ ] Start a rewind capture; confirm events accumulate from page-load time (allowing for the small idle deferral).