### PR TITLE
perf(storage): batch listener notifications + dedupe shared subscriptions [Phase 4]

### DIFF
--- a/packages/storage/lib/base/base.ts
+++ b/packages/storage/lib/base/base.ts
@@ -100,13 +100,24 @@ export const createStorage = <D = string>(key: string, fallback: D, config?: Sto
     return deserialize(value[key] as string) ?? fallback;
   };
 
+  // Coalesce a burst of set() calls into a single listener notification per microtask. Multiple
+  // synchronous mutations now produce one re-render cycle instead of N.
+  let notifyScheduled = false;
   const _emitChange = () => {
-    listeners.forEach(listener => listener());
+    if (notifyScheduled) return;
+    notifyScheduled = true;
+    queueMicrotask(() => {
+      notifyScheduled = false;
+      listeners.forEach(listener => listener());
+    });
   };
 
   const set = async (valueOrUpdate: ValueOrUpdate<D>) => {
     if (!initedCache) {
       cache = await get();
+      // Mark the cache initialised so subsequent set() calls don't each issue a redundant
+      // chrome.storage.get when the initial get().then() at module load hasn't resolved yet.
+      initedCache = true;
     }
     cache = await updateCache(valueOrUpdate, cache);
 

--- a/packages/storage/lib/factories/index.ts
+++ b/packages/storage/lib/factories/index.ts
@@ -1,1 +1,2 @@
 export { createAnnotationStorage } from './annotation-storage.factory.js';
+export type { Annotations, AnnotationsStorage } from './annotation-storage.factory.js';

--- a/packages/storage/lib/index.ts
+++ b/packages/storage/lib/index.ts
@@ -1,2 +1,3 @@
 export type { BaseStorage } from './base/index.js';
+export * from './factories/index.js';
 export * from './impl/index.js';

--- a/pages/content-ui/src/components/annotation-view/canvas-wrapper.view.tsx
+++ b/pages/content-ui/src/components/annotation-view/canvas-wrapper.view.tsx
@@ -3,8 +3,6 @@
 import type { RefObject } from 'react';
 import { useCallback } from 'react';
 
-import { useStorage } from '@extension/shared';
-import { annotationsHistoryStorage, annotationsRedoStorage, annotationsStorage } from '@extension/storage';
 import {
   ContextMenu,
   ContextMenuContent,
@@ -14,6 +12,7 @@ import {
 } from '@extension/ui';
 
 import { shortcuts } from '@src/constants';
+import { useAnnotationActionAvailability } from '@src/providers';
 
 type Props = {
   id: string;
@@ -25,13 +24,7 @@ type Props = {
 };
 
 export const CanvasWrapper = ({ id, canvasRef, onUndo, onRedo, onStartOver, onExport }: Props) => {
-  const historyAnnotations = useStorage(annotationsHistoryStorage);
-  const redoAnnotations = useStorage(annotationsRedoStorage);
-  const annotations = useStorage(annotationsStorage);
-
-  const canUndo = historyAnnotations[id]?.objects?.length;
-  const canRedo = redoAnnotations[id]?.objects?.length;
-  const canStartOver = annotations[id]?.objects?.length || canRedo || canUndo;
+  const { canUndo, canRedo, canStartOver } = useAnnotationActionAvailability(id);
 
   const handleContextMenuClick = useCallback(
     (value: string) => {

--- a/pages/content-ui/src/components/annotation-view/ui/header.ui.tsx
+++ b/pages/content-ui/src/components/annotation-view/ui/header.ui.tsx
@@ -1,11 +1,10 @@
 import { IS_DEV } from '@extension/env';
 import { t } from '@extension/i18n';
-import { useStorage } from '@extension/shared';
-import { annotationsHistoryStorage, annotationsRedoStorage, annotationsStorage } from '@extension/storage';
 import type { CreateAction } from '@extension/store';
 import { Button, cn, Icon, Tooltip, TooltipContent, TooltipTrigger } from '@extension/ui';
 
 import { CreateDropdown, EditableTitle, WorkspacesDropdown } from '@src/components/dialog-view';
+import { useAnnotationActionAvailability } from '@src/providers';
 
 interface EditorHeaderProps {
   /** active screenshot id */
@@ -66,13 +65,7 @@ export const Header: React.FC<EditorHeaderProps> = ({
 
   className,
 }) => {
-  const historyAnnotations = useStorage(annotationsHistoryStorage);
-  const redoAnnotations = useStorage(annotationsRedoStorage);
-  const annotations = useStorage(annotationsStorage);
-
-  const canUndo = historyAnnotations[id]?.objects?.length;
-  const canRedo = redoAnnotations[id]?.objects?.length;
-  const canStartOver = annotations[id]?.objects?.length || canRedo || canUndo;
+  const { canUndo, canRedo, canStartOver } = useAnnotationActionAvailability(id);
 
   return (
     <header

--- a/pages/content-ui/src/components/annotation-view/ui/left-sidebar.ui.tsx
+++ b/pages/content-ui/src/components/annotation-view/ui/left-sidebar.ui.tsx
@@ -2,13 +2,12 @@ import type { WheelEvent } from 'react';
 import { useCallback, useMemo, useState } from 'react';
 
 import { t } from '@extension/i18n';
-import { useStorage } from '@extension/shared';
 import type { Screenshot } from '@extension/shared';
-import { annotationsStorage } from '@extension/storage';
 import { Button, cn, Icon, ScrollArea } from '@extension/ui';
 
 import { HoverImage } from '@src/components/dialog-view';
 import { useElementSize } from '@src/hooks';
+import { useAnnotations } from '@src/providers';
 
 interface LeftSidebarProps {
   open?: boolean;
@@ -39,7 +38,7 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
   const isOpen = isControlled ? open! : internalOpen;
 
   const { ref: screenshotsViewRef, height: screenshotsViewHeight } = useElementSize<HTMLDivElement>();
-  const annotations = useStorage(annotationsStorage);
+  const { annotations } = useAnnotations();
 
   const toggle = useCallback(() => {
     const next = !isOpen;

--- a/pages/content-ui/src/content.tsx
+++ b/pages/content-ui/src/content.tsx
@@ -28,6 +28,7 @@ import { RewindPlayer } from './components/recording-view/views/rewind-player.vi
 import { defaultNavElement } from './constants';
 import { useElementSize, useErrorEvents, useViewportSize } from './hooks';
 import type { ActiveElement, HandleOnCreateArgs, TrimRange, VideoFormat, VideoSource } from './models';
+import { AnnotationsProvider } from './providers';
 import { buildEventsFile, exportRecordingVideo } from './utils/recording';
 import {
   buildRecordsFile,
@@ -415,97 +416,99 @@ const Content = ({
           backgroundImage: `url(${bgLight})`,
           backgroundSize: 10,
         }}>
-        {progress > 0 && <Progress className="absolute left-0 top-0 h-1.5 w-full" value={progress} />}
+        <AnnotationsProvider>
+          {progress > 0 && <Progress className="absolute left-0 top-0 h-1.5 w-full" value={progress} />}
 
-        <Header
-          id={activeScreenshotId || ''}
-          onClose={onClose}
-          onMinimize={activeScreenshotId ? onMinimize : undefined}
-          onToggleFullScreen={() => setFullScreen(flag => !flag)}
-          isFullScreen={isFullScreen}
-          title={title}
-          onTitleChange={setTitle}
-          onUndo={() => {
-            dispatch(triggerCanvasAction(CANVAS_ACTION.UNDO));
-          }}
-          onRedo={() => {
-            dispatch(triggerCanvasAction(CANVAS_ACTION.REDO));
-          }}
-          onStartOver={() => {
-            dispatch(triggerCanvasAction(CANVAS_ACTION.START_OVER));
-          }}
-          canvasWidth={canvasWidth}
-          canvasHeight={canvasHeight}
-          onWorkspaceChange={setWorkspaceId}
-          createActions={createActions}
-          activeCreateAction={activeAction}
-          onCreate={handleOnCreateType}
-          isCreateLoading={isCreateLoading}
-        />
-
-        <main
-          ref={canvasRef}
-          className={cn('grid h-full min-h-0 gap-4 p-4 transition-[grid-template-columns] duration-300', gridCols)}>
-          {!!activeScreenshotId && (
-            <LeftSidebar
-              activeScreenshotId={activeScreenshotId}
-              canvasHeight={canvasHeight}
-              open={isLeftSidebarOpen}
-              onOpenChange={handleOnOpenSidebar('left')}
-              screenshots={screenshots}
-              onDelete={onDeleteScreenshot}
-              onSelect={onSelectScreenshot}
-            />
-          )}
-
-          {video?.blob ? (
-            <VideoPlayer
-              video={video}
-              disableExport={isVideoExporting}
-              onExport={handleOnVideoExport}
-              onTrimUpdate={handleOnTrimUpdate}
-            />
-          ) : events?.length ? (
-            <RewindPlayer
-              events={events}
-              errorEvents={errorEvents}
-              onTrimChange={setRrwebTrim}
-              enableTrim
-              showEventsMenu
-            />
-          ) : (
-            <CanvasContainerView
-              key={activeScreenshotId ?? 'empty'}
-              screenshot={activeScreenshot!}
-              onElement={handleOnElement}
-            />
-          )}
-
-          <RightSidebar
-            defaultOpen
-            workspaceId={workspaceId}
+          <Header
+            id={activeScreenshotId || ''}
+            onClose={onClose}
+            onMinimize={activeScreenshotId ? onMinimize : undefined}
+            onToggleFullScreen={() => setFullScreen(flag => !flag)}
+            isFullScreen={isFullScreen}
+            title={title}
+            onTitleChange={setTitle}
+            onUndo={() => {
+              dispatch(triggerCanvasAction(CANVAS_ACTION.UNDO));
+            }}
+            onRedo={() => {
+              dispatch(triggerCanvasAction(CANVAS_ACTION.REDO));
+            }}
+            onStartOver={() => {
+              dispatch(triggerCanvasAction(CANVAS_ACTION.START_OVER));
+            }}
+            canvasWidth={canvasWidth}
             canvasHeight={canvasHeight}
-            open={isRightSidebarOpen}
-            onOpenChange={handleOnOpenSidebar('right')}
-            onCreate={handleOnCreate}
+            onWorkspaceChange={setWorkspaceId}
+            createActions={createActions}
+            activeCreateAction={activeAction}
+            onCreate={handleOnCreateType}
+            isCreateLoading={isCreateLoading}
           />
-        </main>
 
-        <Footer
-          tool={video?.blob ? 'Trim' : activeElement?.name}
-          zoom={100}
-          file={title}
-          duration={trimDuration}
-          trim={trim}
-          onZoomChange={zoom => {
-            /**
-             * @todo
-             * implement zoon feature: min: 100% and max: 100%
-             */
-            console.log('zoom', zoom);
-            // setZoom()
-          }}
-        />
+          <main
+            ref={canvasRef}
+            className={cn('grid h-full min-h-0 gap-4 p-4 transition-[grid-template-columns] duration-300', gridCols)}>
+            {!!activeScreenshotId && (
+              <LeftSidebar
+                activeScreenshotId={activeScreenshotId}
+                canvasHeight={canvasHeight}
+                open={isLeftSidebarOpen}
+                onOpenChange={handleOnOpenSidebar('left')}
+                screenshots={screenshots}
+                onDelete={onDeleteScreenshot}
+                onSelect={onSelectScreenshot}
+              />
+            )}
+
+            {video?.blob ? (
+              <VideoPlayer
+                video={video}
+                disableExport={isVideoExporting}
+                onExport={handleOnVideoExport}
+                onTrimUpdate={handleOnTrimUpdate}
+              />
+            ) : events?.length ? (
+              <RewindPlayer
+                events={events}
+                errorEvents={errorEvents}
+                onTrimChange={setRrwebTrim}
+                enableTrim
+                showEventsMenu
+              />
+            ) : (
+              <CanvasContainerView
+                key={activeScreenshotId ?? 'empty'}
+                screenshot={activeScreenshot!}
+                onElement={handleOnElement}
+              />
+            )}
+
+            <RightSidebar
+              defaultOpen
+              workspaceId={workspaceId}
+              canvasHeight={canvasHeight}
+              open={isRightSidebarOpen}
+              onOpenChange={handleOnOpenSidebar('right')}
+              onCreate={handleOnCreate}
+            />
+          </main>
+
+          <Footer
+            tool={video?.blob ? 'Trim' : activeElement?.name}
+            zoom={100}
+            file={title}
+            duration={trimDuration}
+            trim={trim}
+            onZoomChange={zoom => {
+              /**
+               * @todo
+               * implement zoon feature: min: 100% and max: 100%
+               */
+              console.log('zoom', zoom);
+              // setZoom()
+            }}
+          />
+        </AnnotationsProvider>
       </DialogContent>
     </Dialog>
   );

--- a/pages/content-ui/src/providers/annotations.provider.tsx
+++ b/pages/content-ui/src/providers/annotations.provider.tsx
@@ -1,0 +1,51 @@
+import { createContext, useContext, useMemo } from 'react';
+import type { PropsWithChildren } from 'react';
+
+import { useStorage } from '@extension/shared';
+import type { Annotations } from '@extension/storage';
+import { annotationsHistoryStorage, annotationsRedoStorage, annotationsStorage } from '@extension/storage';
+
+type AnnotationMap = Record<string, Annotations>;
+
+type AnnotationsContextValue = {
+  annotations: AnnotationMap;
+  historyAnnotations: AnnotationMap;
+  redoAnnotations: AnnotationMap;
+};
+
+const AnnotationsContext = createContext<AnnotationsContextValue | null>(null);
+
+/**
+ * Subscribes to the three annotation storages once and shares the result via context. Previous
+ * implementation had Header, CanvasWrapper, and LeftSidebar each calling useStorage on the same
+ * three storages, producing 3x listener calls + 3x re-render cycles per annotation write.
+ */
+export const AnnotationsProvider = ({ children }: PropsWithChildren) => {
+  const annotations = useStorage(annotationsStorage);
+  const historyAnnotations = useStorage(annotationsHistoryStorage);
+  const redoAnnotations = useStorage(annotationsRedoStorage);
+
+  const value = useMemo(
+    () => ({ annotations, historyAnnotations, redoAnnotations }),
+    [annotations, historyAnnotations, redoAnnotations],
+  );
+
+  return <AnnotationsContext.Provider value={value}>{children}</AnnotationsContext.Provider>;
+};
+
+export const useAnnotations = (): AnnotationsContextValue => {
+  const ctx = useContext(AnnotationsContext);
+  if (!ctx) throw new Error('useAnnotations must be used inside <AnnotationsProvider>.');
+  return ctx;
+};
+
+export const useAnnotationActionAvailability = (id: string) => {
+  const { annotations, historyAnnotations, redoAnnotations } = useAnnotations();
+
+  return useMemo(() => {
+    const canUndo = (historyAnnotations[id]?.objects?.length ?? 0) > 0;
+    const canRedo = (redoAnnotations[id]?.objects?.length ?? 0) > 0;
+    const canStartOver = (annotations[id]?.objects?.length ?? 0) > 0 || canRedo || canUndo;
+    return { canUndo, canRedo, canStartOver };
+  }, [id, annotations, historyAnnotations, redoAnnotations]);
+};

--- a/pages/content-ui/src/providers/index.ts
+++ b/pages/content-ui/src/providers/index.ts
@@ -1,0 +1,1 @@
+export { AnnotationsProvider, useAnnotations, useAnnotationActionAvailability } from './annotations.provider';

--- a/pages/popup/src/components/capture/capture-content.view.tsx
+++ b/pages/popup/src/components/capture/capture-content.view.tsx
@@ -30,8 +30,14 @@ import {
 
 import { CaptureScreenshotView, CaptureSessionView, RecordVideoView } from './views';
 
-export const CaptureContentView = ({ onActiveTabChange }: { onActiveTabChange: (id: number | null) => void }) => {
-  const { state, mode } = useStorage<BaseStorage<CaptureState>>(captureStateStorage);
+type CaptureContentViewProps = {
+  onActiveTabChange: (id: number | null) => void;
+  /** Provided by parent so we don't double-subscribe to captureStateStorage. */
+  captureState: CaptureState;
+};
+
+export const CaptureContentView = ({ onActiveTabChange, captureState }: CaptureContentViewProps) => {
+  const { state, mode } = captureState;
   const { rewind } = useStorage<BaseStorage<RewindSettings>>(rewindSettingsStorage);
   const { mic } = useStorage<BaseStorage<RecordingSettings>>(recordingSettingsStorage);
 

--- a/pages/popup/src/popup-content.tsx
+++ b/pages/popup/src/popup-content.tsx
@@ -148,6 +148,7 @@ export const PopupContent = ({
   return (
     <>
       <CaptureContentView
+        captureState={{ state, mode }}
         onActiveTabChange={id => {
           setActiveTab(prev => ({ ...prev, id }));
         }}


### PR DESCRIPTION
## Summary

Phase 4 of the refactor/performance roadmap. Multiple simultaneously-mounted React components were independently subscribing to the same `chrome.storage` key, producing N listener callbacks + N re-render cycles per write.

### Changes
- **packages/storage/lib/base/base.ts**
  - `_emitChange` now coalesces via `queueMicrotask` — multiple synchronous `set()` calls in the same tick produce one notification.
  - `set()` flips `initedCache = true` after the cold-path `await get()` so sequential pre-init writes don't each redundantly fetch.
- **packages/storage**: re-export `Annotations` / `AnnotationsStorage` types through the barrel.
- **content-ui**: new `AnnotationsProvider` subscribes to `annotationsStorage`, `annotationsHistoryStorage`, `annotationsRedoStorage` once. `useAnnotations()` + `useAnnotationActionAvailability(id)` hooks. Header, CanvasWrapper, LeftSidebar consume the context — drops `annotationsStorage` subscribers from 3 → 1; history/redo from 2 → 1.
- **popup**: `CaptureContentView` now receives `captureState` as a prop from `PopupContent` (was a second subscriber to `captureStateStorage`).

## Test plan
- [x] `pnpm type-check` + `pnpm build:chrome:production` pass.
- [ ] Load in Chrome; open the annotation editor; draw a few strokes — verify undo/redo/start-over enable/disable correctly in both the Header buttons and the canvas right-click context menu.
- [ ] React Profiler: drawing one annotation should produce ≤1 render of Header/CanvasWrapper/LeftSidebar (was 3 each).
- [ ] Popup: start/pause/finish a capture; verify state propagation between popup and capture views still works.
- [ ] Verify no React warnings about consumers used outside `AnnotationsProvider`.