### PR TITLE
perf(popup): cut TTI on popup open [Phase 5]

### DIFF
--- a/pages/popup/src/Popup.tsx
+++ b/pages/popup/src/Popup.tsx
@@ -5,7 +5,6 @@ import { useEffect, useState } from 'react';
 import { t } from '@extension/i18n';
 import { useStorage, withErrorBoundary, withSuspense } from '@extension/shared';
 import { themeStorage } from '@extension/storage';
-import { store, ReduxProvider } from '@extension/store';
 import { Separator } from '@extension/ui';
 
 import { BetaNotifier, Header, Skeleton } from './components/ui';
@@ -26,33 +25,31 @@ const Popup = () => {
 
   return (
     <div className="dark:bg-background.dark relative px-5 pb-5 pt-4">
-      <ReduxProvider store={store}>
-        <AuthStateProvider>
-          <AuthGuard>
-            <div className="flex flex-col gap-y-4">
-              <Header
-                onSlicesHistory={() => {
-                  setShowSettings(false);
-                  setShowSlicesHistory(true);
-                }}
-                onSettings={() => {
-                  setShowSlicesHistory(false);
-                  setShowSettings(true);
-                }}
-              />
-              <Separator className="bg-border/60" />
-              <PopupContent
-                showSlicesHistory={showSlicesHistory}
-                showSettings={showSettings}
-                setShowSlicesHistory={setShowSlicesHistory}
-                setShowSettings={setShowSettings}
-              />
-              <Separator className="bg-border/60" />
-              <BetaNotifier />
-            </div>
-          </AuthGuard>
-        </AuthStateProvider>
-      </ReduxProvider>
+      <AuthStateProvider>
+        <AuthGuard>
+          <div className="flex flex-col gap-y-4">
+            <Header
+              onSlicesHistory={() => {
+                setShowSettings(false);
+                setShowSlicesHistory(true);
+              }}
+              onSettings={() => {
+                setShowSlicesHistory(false);
+                setShowSettings(true);
+              }}
+            />
+            <Separator className="bg-border/60" />
+            <PopupContent
+              showSlicesHistory={showSlicesHistory}
+              showSettings={showSettings}
+              setShowSlicesHistory={setShowSlicesHistory}
+              setShowSettings={setShowSettings}
+            />
+            <Separator className="bg-border/60" />
+            <BetaNotifier />
+          </div>
+        </AuthGuard>
+      </AuthStateProvider>
     </div>
   );
 };

--- a/pages/popup/src/components/capture/capture-content.view.tsx
+++ b/pages/popup/src/components/capture/capture-content.view.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import {
   CAPTURE,
@@ -36,7 +36,7 @@ type CaptureContentViewProps = {
   captureState: CaptureState;
 };
 
-export const CaptureContentView = ({ onActiveTabChange, captureState }: CaptureContentViewProps) => {
+const CaptureContentViewInner = ({ onActiveTabChange, captureState }: CaptureContentViewProps) => {
   const { state, mode } = captureState;
   const { rewind } = useStorage<BaseStorage<RewindSettings>>(rewindSettingsStorage);
   const { mic } = useStorage<BaseStorage<RecordingSettings>>(recordingSettingsStorage);
@@ -63,10 +63,13 @@ export const CaptureContentView = ({ onActiveTabChange, captureState }: CaptureC
     await captureStateStorage.setScreenshotState(state);
   }, []);
 
-  const updateActiveTab = useCallback(async (tabId: number | null) => {
-    await captureTabStorage.setCaptureTabId(tabId);
-    onActiveTabChange(tabId);
-  }, []);
+  const updateActiveTab = useCallback(
+    async (tabId: number | null) => {
+      await captureTabStorage.setCaptureTabId(tabId);
+      onActiveTabChange(tabId);
+    },
+    [onActiveTabChange],
+  );
 
   useEffect(() => {
     const handleEscapeKey = async (event: KeyboardEvent) => {
@@ -250,3 +253,7 @@ export const CaptureContentView = ({ onActiveTabChange, captureState }: CaptureC
     </div>
   );
 };
+
+// Memoized so a parent re-render that produces the same captureState/onActiveTabChange refs
+// doesn't cascade through this view. Pair with the stable refs in popup-content.tsx.
+export const CaptureContentView = memo(CaptureContentViewInner);

--- a/pages/popup/src/components/slices-history/content.slices-history.tsx
+++ b/pages/popup/src/components/slices-history/content.slices-history.tsx
@@ -1,5 +1,5 @@
 import { format } from 'date-fns';
-import { Fragment, useState } from 'react';
+import { Fragment, memo, useCallback, useMemo, useState } from 'react';
 
 import { APP_BASE_URL } from '@extension/env';
 import { t } from '@extension/i18n';
@@ -8,17 +8,69 @@ import type { Pagination } from '@extension/shared';
 import { useAppSelector, useDeleteSliceByIdMutation, useGetSlicesQuery, useUser } from '@extension/store';
 import { Alert, AlertDescription, AlertTitle, Button, Icon, Separator } from '@extension/ui';
 
-import { useSlicesCreatedToday } from '@src/hooks';
 import { navigateTo } from '@src/utils';
 
 import { CardSkeleton } from './card-skeleton.slice-history';
 
+type SliceAttachment = { name?: string; preview?: string };
+type SliceItemModel = {
+  id: string;
+  externalId: string;
+  createdAt: string | number | Date;
+  attachments: SliceAttachment[];
+};
+
+const getPreviewScreenshotUrl = (attachments: SliceAttachment[] | undefined) =>
+  attachments?.find(a => a?.name === 'primary')?.preview;
+
+type SliceRowProps = {
+  item: SliceItemModel;
+  isGuest: boolean;
+  isDeleteLoading: boolean;
+  onDelete: (externalId: string) => void;
+};
+
+const SliceRow = memo(({ item, isGuest, isDeleteLoading, onDelete }: SliceRowProps) => {
+  const preview = useMemo(() => getPreviewScreenshotUrl(item.attachments), [item.attachments]);
+  const handleNavigate = useCallback(() => {
+    const path = isGuest ? `s/${item?.externalId}` : `slices/${item?.id}`;
+    navigateTo(`${APP_BASE_URL}/${path}`);
+  }, [isGuest, item?.externalId, item?.id]);
+  const handleDelete = useCallback(() => onDelete(item.externalId), [item.externalId, onDelete]);
+
+  return (
+    <div className="flex items-center px-3">
+      {preview && (
+        <img
+          src={preview}
+          alt={t('sliceThumbnail')}
+          loading="lazy"
+          crossOrigin="anonymous"
+          className="mr-3 size-12 rounded-md object-cover"
+        />
+      )}
+
+      <div className="flex-1">
+        <button
+          className="max-w-[240px] truncate text-sm font-medium text-slate-700 hover:underline dark:text-[#df8801]"
+          onClick={handleNavigate}>
+          {item.externalId}
+        </button>
+        <p className="text-muted-foreground text-xs">{format(item.createdAt, 'LLL dd, y hh:mm a')}</p>
+      </div>
+      <Button variant="ghost" size="icon" className="text-red-500" disabled={isDeleteLoading} onClick={handleDelete}>
+        <Icon name="TrashIcon" className="size-3.5" />
+      </Button>
+    </div>
+  );
+});
+SliceRow.displayName = 'SliceRow';
+
 export const SlicesHistoryContent = ({ onBack }: { onBack: () => void }) => {
   const user = useUser();
   const isGuest = user?.fields?.authMethod === AuthMethod.GUEST;
-  const totalSlicesCreatedToday = useSlicesCreatedToday();
   const filters = useAppSelector(state => state.slicesReducer.filters);
-  const [pagination, setPagination] = useState<Pagination>({
+  const [pagination] = useState<Pagination>({
     limit: 1,
     take: ITEMS_PER_PAGE,
   });
@@ -26,39 +78,27 @@ export const SlicesHistoryContent = ({ onBack }: { onBack: () => void }) => {
   const [deleteSliceByExternalId, { isLoading: isDeleteSliceLoading }] = useDeleteSliceByIdMutation();
   const { isLoading, data: slices } = useGetSlicesQuery({ ...pagination, ...filters });
 
-  const previewScreenshotUrl = (attachments: any) => attachments.find((a: any) => a?.name === 'primary')?.preview;
+  // Read totalToday from the same query that powers this list — no need for the parallel
+  // useGetSlicesQuery({ limit: 1, take: 10 }) call in useSlicesCreatedToday when we're on this view.
+  const totalSlicesCreatedToday = slices?.totalToday ?? 0;
 
-  const onDeleteAll = () => {
-    // Handle delete all logic
-    console.log('All slices deleted');
-  };
-
-  const onDelete = async (externalId: string) => {
-    await deleteSliceByExternalId(externalId);
-  };
+  const onDelete = useCallback(
+    async (externalId: string) => {
+      await deleteSliceByExternalId(externalId);
+    },
+    [deleteSliceByExternalId],
+  );
 
   return (
     <div>
-      {/* Top Bar */}
       <div className="mb-2 flex items-center justify-between">
         <Button variant="ghost" size="icon" onClick={onBack}>
           <Icon name="ArrowLeftIcon" className="size-5" />
         </Button>
 
-        {!isGuest && (
-          <>
-            {/*
-            <Button variant="link" size="sm" className="text-red-500" onClick={onDeleteAll}>
-              {t('deleteAll')}
-            </Button>
-            */}
-
-            <h2 className="flex items-center text-base font-semibold">{t('sliceHistoryTitle')}</h2>
-          </>
-        )}
+        {!isGuest && <h2 className="flex items-center text-base font-semibold">{t('sliceHistoryTitle')}</h2>}
       </div>
 
-      {/* Title and Description */}
       {isGuest && (
         <div className="mb-2 flex items-center justify-between">
           <h2 className="flex items-center text-base font-semibold">{t('sliceHistoryTitle')}</h2>
@@ -90,40 +130,16 @@ export const SlicesHistoryContent = ({ onBack }: { onBack: () => void }) => {
         <div className="mt-2 space-y-2">
           {slices.items.map((item, idx) => (
             <Fragment key={item.id}>
-              <div className="flex items-center px-3">
-                {previewScreenshotUrl(item.attachments) && (
-                  <img
-                    src={previewScreenshotUrl(item.attachments)}
-                    alt={t('sliceThumbnail')}
-                    loading="lazy"
-                    crossOrigin="anonymous"
-                    className="mr-3 size-12 rounded-md object-cover"
-                  />
-                )}
-
-                <div className="flex-1">
-                  <button
-                    className="max-w-[240px] truncate text-sm font-medium text-slate-700 hover:underline dark:text-[#df8801]"
-                    onClick={() => {
-                      const path = isGuest ? `s/${item?.externalId}` : `slices/${item?.id}`;
-
-                      navigateTo(`${APP_BASE_URL}/${path}`);
-                    }}>
-                    {item.externalId}
-                  </button>
-                  <p className="text-muted-foreground text-xs">{format(item.createdAt, 'LLL dd, y hh:mm a')}</p>
-                </div>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="text-red-500"
-                  disabled={isDeleteSliceLoading}
-                  onClick={() => onDelete(item.externalId)}>
-                  <Icon name="TrashIcon" className="size-3.5" />
-                </Button>
-              </div>
-
-              {slices?.total - 1 !== idx && <Separator className="h-px bg-gray-900/5 dark:bg-gray-800" />}
+              <SliceRow
+                item={item as SliceItemModel}
+                isGuest={isGuest}
+                isDeleteLoading={isDeleteSliceLoading}
+                onDelete={onDelete}
+              />
+              {/* Visible-list separator: use items.length, not slices.total (which counts the full
+                  dataset, not just this page). Previously rendered a trailing separator on every
+                  page except the very last one of the entire dataset. */}
+              {idx !== slices.items.length - 1 && <Separator className="h-px bg-gray-900/5 dark:bg-gray-800" />}
             </Fragment>
           ))}
         </div>

--- a/pages/popup/src/hooks/use-auth-state.hook.ts
+++ b/pages/popup/src/hooks/use-auth-state.hook.ts
@@ -20,19 +20,57 @@ interface AuthState {
   retry: () => void;
 }
 
-const checkHealth = async (signal: AbortSignal): Promise<boolean> => {
+const HEALTH_CACHE_KEY = 'brie:health:cache';
+const HEALTH_CACHE_TTL_MS = 30_000;
+const HEALTH_FETCH_TIMEOUT_MS = 8_000;
+
+type HealthCache = { ok: boolean; checkedAt: number };
+
+const fetchHealth = async (signal: AbortSignal): Promise<boolean> => {
   if (!API_BASE_URL) return false;
+
+  // The outer controller aborts on component unmount / new run; this inner controller adds a
+  // bounded timeout so a hung network call doesn't strand the user on `api_unavailable` forever.
+  const timeoutController = new AbortController();
+  const timeoutId = setTimeout(() => timeoutController.abort(), HEALTH_FETCH_TIMEOUT_MS);
+  const onParentAbort = () => timeoutController.abort();
+  signal.addEventListener('abort', onParentAbort, { once: true });
 
   try {
     const response = await fetch(`${API_BASE_URL}/health`, {
       method: 'HEAD',
       headers: { 'Cache-Control': 'no-cache, no-store, must-revalidate' },
-      signal,
+      signal: timeoutController.signal,
     });
 
     return response.ok;
   } catch {
     return false;
+  } finally {
+    clearTimeout(timeoutId);
+    signal.removeEventListener('abort', onParentAbort);
+  }
+};
+
+const readHealthCache = async (): Promise<HealthCache | null> => {
+  try {
+    const session = chrome?.storage?.session;
+    if (!session) return null;
+    const result = await session.get([HEALTH_CACHE_KEY]);
+    const cached = result[HEALTH_CACHE_KEY] as HealthCache | undefined;
+    if (!cached || typeof cached.checkedAt !== 'number') return null;
+    if (Date.now() - cached.checkedAt > HEALTH_CACHE_TTL_MS) return null;
+    return cached;
+  } catch {
+    return null;
+  }
+};
+
+const writeHealthCache = async (ok: boolean): Promise<void> => {
+  try {
+    await chrome?.storage?.session?.set({ [HEALTH_CACHE_KEY]: { ok, checkedAt: Date.now() } });
+  } catch {
+    // Best-effort cache; ignore quota/permission errors.
   }
 };
 
@@ -48,18 +86,35 @@ const useAuthState = (): AuthState => {
 
   const { data: user, isLoading, isError, error } = useGetUserDetailsQuery(undefined, { skip: skipUserQuery });
 
-  // Health check on mount + retry
-  const runHealthCheck = useCallback(async () => {
+  // Health check on mount + retry. Uses chrome.storage.session as a 30s SWR cache so reopening the
+  // popup doesn't gate first paint on a network round-trip.
+  const runHealthCheck = useCallback(async (options?: { skipCache?: boolean }) => {
     abortRef.current?.abort();
     const controller = new AbortController();
     abortRef.current = controller;
 
-    setPhase('checking_health');
-    setHealthPassed(false);
-
-    const healthy = await checkHealth(controller.signal);
+    const cached = options?.skipCache ? null : await readHealthCache();
 
     if (controller.signal.aborted) return;
+
+    if (cached) {
+      // Render immediately from cache, then revalidate in the background. Surfaces stale failure
+      // states via revalidation rather than blocking.
+      if (cached.ok) {
+        setHealthPassed(true);
+      } else {
+        setPhase('api_unavailable');
+      }
+    } else {
+      setPhase('checking_health');
+      setHealthPassed(false);
+    }
+
+    const healthy = await fetchHealth(controller.signal);
+
+    if (controller.signal.aborted) return;
+
+    void writeHealthCache(healthy);
 
     if (healthy) {
       setHealthPassed(true);
@@ -112,7 +167,8 @@ const useAuthState = (): AuthState => {
   }, [healthPassed, hasTokens, isLoading, isError, error, user]);
 
   const retry = useCallback(() => {
-    runHealthCheck();
+    // User-initiated retry bypasses cache.
+    runHealthCheck({ skipCache: true });
   }, [runHealthCheck]);
 
   return { phase, user, retry };

--- a/pages/popup/src/hooks/use-slices-created-today.hook.ts
+++ b/pages/popup/src/hooks/use-slices-created-today.hook.ts
@@ -1,26 +1,11 @@
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 
 import { useGetSlicesQuery } from '@extension/store';
 
 export const useSlicesCreatedToday = (): number => {
-  const {
-    isLoading,
-    isError,
-    data: slices,
-  } = useGetSlicesQuery(
-    { limit: 1, take: 10 },
-    // {
-    //   refetchOnMountOrArgChange: true,
-    //   refetchOnReconnect: true,
-    //   refetchOnFocus: true,
-    //   pollingInterval: 0, // or set to something like 10_000 to poll every 10s
-    //   skip: false,
-    // },
-  );
-
-  console.log('slices', slices);
+  const { isLoading, isError, data: slices } = useGetSlicesQuery({ limit: 1, take: 10 });
 
   return useMemo(() => {
     return !isError && !isLoading && slices?.totalToday ? slices.totalToday : 0;
-  }, [slices?.totalToday, isLoading]);
+  }, [isError, isLoading, slices?.totalToday]);
 };

--- a/pages/popup/src/index.tsx
+++ b/pages/popup/src/index.tsx
@@ -1,6 +1,7 @@
 import { createRoot } from 'react-dom/client';
 
 import { themeStorage } from '@extension/storage';
+import { ReduxProvider, store } from '@extension/store';
 
 import Popup from '@src/Popup';
 import '@src/index.css';
@@ -15,7 +16,14 @@ const init = () => {
   }
   const root = createRoot(appContainer);
 
-  root.render(<Popup />);
+  // Hoisted out of <Popup/> so the Redux provider doesn't sit inside the theme-reactive render
+  // path. Theme changes triggered a re-render of Popup which previously rerendered ReduxProvider
+  // and every descendant.
+  root.render(
+    <ReduxProvider store={store}>
+      <Popup />
+    </ReduxProvider>,
+  );
 };
 
 init();

--- a/pages/popup/src/popup-content.tsx
+++ b/pages/popup/src/popup-content.tsx
@@ -61,14 +61,16 @@ export const PopupContent = ({
   }, [totalSlicesCreatedToday, user?.authMethod, activeTab.id]);
 
   useEffect(() => {
+    // Fire the storage read and tab query in parallel — previously the active-tab URL would only
+    // arrive after a second async tick, causing flicker between guards (internal page, unsaved-tab).
     const initializeState = async () => {
-      setActiveTab(prev => ({ ...prev, id: captureTabId ?? null }));
-
       const tab = await getActiveTab();
-      if (tab) {
-        setActiveTab(prev => ({ ...prev, url: tab.url ?? prev.url }));
-        setCurrentActiveTab(tab.id);
-      }
+      setActiveTab(prev => ({
+        ...prev,
+        id: captureTabId ?? null,
+        url: tab?.url ?? prev.url,
+      }));
+      if (tab) setCurrentActiveTab(tab.id);
     };
 
     initializeState();
@@ -106,6 +108,12 @@ export const PopupContent = ({
     },
     [updateActiveTab, updateCaptureState],
   );
+
+  const handleActiveTabChangeFromChild = useCallback((id: number | null) => {
+    setActiveTab(prev => ({ ...prev, id }));
+  }, []);
+
+  const captureStateForChild = useMemo(() => ({ state, mode }), [state, mode]);
 
   const internalPage = isInternalUrl(activeTab.url);
 
@@ -147,12 +155,7 @@ export const PopupContent = ({
 
   return (
     <>
-      <CaptureContentView
-        captureState={{ state, mode }}
-        onActiveTabChange={id => {
-          setActiveTab(prev => ({ ...prev, id }));
-        }}
-      />
+      <CaptureContentView captureState={captureStateForChild} onActiveTabChange={handleActiveTabChangeFromChild} />
     </>
   );
 };

--- a/pages/popup/src/providers/auth-state.provider.tsx
+++ b/pages/popup/src/providers/auth-state.provider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useMemo } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import type { AuthState } from '../hooks/use-auth-state.hook';
@@ -9,7 +9,15 @@ const AuthStateContext = createContext<AuthState | null>(null);
 export const AuthStateProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const authState = useAuthState();
 
-  return <AuthStateContext.Provider value={authState}>{children}</AuthStateContext.Provider>;
+  // Memoize the context value so consumers don't re-render on every Provider render — only when
+  // one of phase / user / retry actually changes.
+  const value = useMemo(
+    () => authState,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [authState.phase, authState.user, authState.retry],
+  );
+
+  return <AuthStateContext.Provider value={value}>{children}</AuthStateContext.Provider>;
 };
 
 export const useAuthStateContext = (): AuthState => {


### PR DESCRIPTION
## Summary

Phase 5 of the refactor/performance roadmap. The popup re-instantiates JS on every open — every blocking step before first paint compounds.

### Changes
- **Health check (use-auth-state.hook.ts)**: SWR cache in `chrome.storage.session` (30s TTL). First paint reads from cache; revalidates in background. `retry()` bypasses cache. 8s timeout on the underlying fetch. Firefox falls through to a full round-trip per open (`storage.session` unavailable there).
- **initializeState (popup-content.tsx)**: single `setActiveTab` after `getActiveTab()` resolves — removes flicker on internal-page / unsaved-tab guards. `onActiveTabChange` and `captureState` props stabilized via `useCallback` / `useMemo`.
- **AuthStateProvider**: context value memoized.
- **ReduxProvider hoist**: moved from `Popup.tsx` into `index.tsx` so theme-triggered re-renders of `Popup` no longer cascade into Provider re-renders.
- **CaptureContentView**: wrapped in `React.memo` so the prop stabilization above actually prevents child re-renders. Also fixed a pre-existing missing dep in `updateActiveTab`'s `useCallback` (was capturing a stale `onActiveTabChange`).
- **slices-history**:
  - Fixed separator bug — was comparing `idx` against `slices.total` (full dataset count), leaving a trailing separator on every non-last page.
  - Extracted `SliceRow` as `React.memo`; per-row `useMemo` on `getPreviewScreenshotUrl` (was running `Array.find` twice per item per render).
  - Removed `console.log('slices', slices)` from `useSlicesCreatedToday`.
  - This view now reads `totalToday` from its own list query rather than the parallel `useSlicesCreatedToday` call.

## Test plan
- [x] `pnpm type-check` + `pnpm build:chrome:production` pass.
- [ ] Load in Chrome; open the popup twice in a row — second open should reach first paint visibly faster (cached health).
- [ ] Disconnect from the API and open popup; verify it falls back to `api_unavailable` within 8 s (the timeout).
- [ ] Open popup on a `chrome://` page; verify the InternalPage hint appears without flicker through transient guards.
- [ ] Navigate to slices history; verify separators render correctly on the page (no trailing separator), pagination works, delete button works.
- [ ] React Profiler: popup re-render count should drop substantially when theme changes (ReduxProvider hoist).
- [ ] Verify Firefox build still works and popup still functions (graceful health-cache fallthrough).