### PR TITLE
perf(content-ui,content-runtime): canvas hygiene + re-injection safety [Phase 6]

### DIFF
--- a/pages/content-runtime/package.json
+++ b/pages/content-runtime/package.json
@@ -19,11 +19,7 @@
     "format": "prettier . --write --ignore-path ../../.prettierignore",
     "type-check": "tsc --noEmit"
   },
-  "dependencies": {
-    "@extension/shared": "workspace:*",
-    "@extension/storage": "workspace:*",
-    "@extension/ui": "workspace:*"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@extension/tsconfig": "workspace:*",
     "@extension/vite-config": "workspace:*"

--- a/pages/content-runtime/src/Root.tsx
+++ b/pages/content-runtime/src/Root.tsx
@@ -1,11 +1,32 @@
+import type { Root } from 'react-dom/client';
 import { createRoot } from 'react-dom/client';
 
 import App from '@src/App';
 import injectedStyle from '@src/index.css?inline';
 
+const ROOT_ID = 'brie-runtime-root';
+
+let activeRoot: Root | null = null;
+
 export const mount = () => {
+  // Re-injection guard: if a previous mount() call already added the host element, do nothing.
+  // Without this, repeat injection (e.g. retry, SPA navigation) would create a second React tree
+  // and orphan the first — its event listeners, closures, and storage subscriptions all leak.
+  if (document.getElementById(ROOT_ID)) return;
+
+  // SPA edge case: a previous activeRoot exists but its host element was nuked by a router that
+  // replaced document.body. Tear the old root down before creating a new one so we don't leak.
+  if (activeRoot) {
+    try {
+      activeRoot.unmount();
+    } catch {
+      // Best-effort; root may already be invalid.
+    }
+    activeRoot = null;
+  }
+
   const root = document.createElement('div');
-  root.id = 'brie-runtime-root';
+  root.id = ROOT_ID;
 
   document.body.append(root);
 
@@ -22,7 +43,8 @@ export const mount = () => {
      * Injecting styles into the document, this may cause style conflicts with the host page
      */
     const styleElement = document.createElement('style');
-    styleElement.innerHTML = injectedStyle;
+    // Bundled CSS string from Vite's ?inline import — not untrusted input.
+    styleElement.textContent = injectedStyle;
     shadowRoot.appendChild(styleElement);
   } else {
     /** Inject styles into shadow dom */
@@ -32,5 +54,12 @@ export const mount = () => {
   }
 
   shadowRoot.appendChild(rootIntoShadow);
-  createRoot(rootIntoShadow).render(<App />);
+  activeRoot = createRoot(rootIntoShadow);
+  activeRoot.render(<App />);
+};
+
+export const unmount = () => {
+  activeRoot?.unmount();
+  activeRoot = null;
+  document.getElementById(ROOT_ID)?.remove();
 };

--- a/pages/content-ui/package.json
+++ b/pages/content-ui/package.json
@@ -33,7 +33,6 @@
     "@rrweb/types": "2.0.0-alpha.18",
     "fabric": "6.6.7",
     "file-saver": "^2.0.5",
-    "moment": "^2.30.1",
     "rrweb": "2.0.0-alpha.4",
     "rrweb-player": "1.0.0-alpha.4",
     "uuid": "^14.0.0"

--- a/pages/content-ui/src/components/annotation-view/canvas-container.view.tsx
+++ b/pages/content-ui/src/components/annotation-view/canvas-container.view.tsx
@@ -312,97 +312,100 @@ const CanvasContainerView = ({ screenshot, onElement }: CanvasContainerProps) =>
    *
    * @param elem
    */
-  const handleActiveElement = (elem: ActiveElement) => {
-    if (elem?.value === 'color-palette') {
-      const highlighterColor = hexToRgba(elem?.payload?.color || elementAttributes.stroke, 0.45);
+  const handleActiveElement = useCallback(
+    (elem: ActiveElement) => {
+      if (elem?.value === 'color-palette') {
+        const highlighterColor = hexToRgba(elem?.payload?.color || elementAttributes.stroke, 0.45);
 
-      currentColorRef.current = elem?.payload?.color || elementAttributes.stroke;
+        currentColorRef.current = elem?.payload?.color || elementAttributes.stroke;
 
-      if (fabricRef.current?.isDrawingMode) {
-        (fabricRef.current.freeDrawingBrush as PencilBrush).color = highlighterColor;
+        if (fabricRef.current?.isDrawingMode) {
+          (fabricRef.current.freeDrawingBrush as PencilBrush).color = highlighterColor;
+        }
+
+        setElementAttributes(prevAttributes => ({
+          ...prevAttributes,
+          stroke: highlighterColor,
+        }));
+
+        modifyShape({
+          canvas: fabricRef.current!,
+          property: 'stroke',
+          value: highlighterColor,
+          activeObjectRef,
+          syncShapeInStorage,
+        });
+
+        return;
       }
 
-      setElementAttributes(prevAttributes => ({
-        ...prevAttributes,
-        stroke: highlighterColor,
-      }));
+      setActiveElement(elem);
+      onElement(elem);
 
-      modifyShape({
-        canvas: fabricRef.current!,
-        property: 'stroke',
-        value: highlighterColor,
-        activeObjectRef,
-        syncShapeInStorage,
-      });
+      switch (elem?.value) {
+        case 'undo':
+          undo();
+          break;
 
-      return;
-    }
+        case 'redo':
+          redo();
+          break;
 
-    setActiveElement(elem);
-    onElement(elem);
+        // delete all the shapes from the canvas
+        case 'start_over':
+          // clear the storage
+          deleteAllShapes();
+          // clear the canvas
+          fabricRef.current?.clear();
+          // set "select" as the active element
+          setActiveElement(defaultNavElement);
+          break;
 
-    switch (elem?.value) {
-      case 'undo':
-        undo();
-        break;
+        // delete the selected shape from the canvas
+        case 'delete':
+          // delete it from the canvas
+          handleDelete(fabricRef.current as any, deleteShapeFromStorage);
+          // set "select" as the active element
+          setActiveElement(defaultNavElement);
+          break;
 
-      case 'redo':
-        redo();
-        break;
+        // upload an image to the canvas
+        case 'image':
+          // trigger the click event on the input element which opens the file dialog
+          imageInputRef.current?.click();
+          /**
+           * set drawing mode to false
+           * If the user is drawing on the canvas, we want to stop the
+           * drawing mode when clicked on the image item from the dropdown.
+           */
+          isDrawing.current = false;
 
-      // delete all the shapes from the canvas
-      case 'start_over':
-        // clear the storage
-        deleteAllShapes();
-        // clear the canvas
-        fabricRef.current?.clear();
-        // set "select" as the active element
-        setActiveElement(defaultNavElement);
-        break;
-
-      // delete the selected shape from the canvas
-      case 'delete':
-        // delete it from the canvas
-        handleDelete(fabricRef.current as any, deleteShapeFromStorage);
-        // set "select" as the active element
-        setActiveElement(defaultNavElement);
-        break;
-
-      // upload an image to the canvas
-      case 'image':
-        // trigger the click event on the input element which opens the file dialog
-        imageInputRef.current?.click();
-        /**
-         * set drawing mode to false
-         * If the user is drawing on the canvas, we want to stop the
-         * drawing mode when clicked on the image item from the dropdown.
-         */
-        isDrawing.current = false;
-
-        if (fabricRef.current) {
-          // disable the drawing mode of canvas
-          fabricRef.current.isDrawingMode = false;
-        }
-        break;
-
-      default:
-        if (fabricRef.current) {
-          if (elem && DRAWING_TOOLS.includes(elem.value)) {
-            isDrawing.current = true;
-            fabricRef.current.isDrawingMode = true;
-
-            applyBrush(elem.value as 'freeform' | 'highlighter', fabricRef.current, currentColorRef);
-          } else {
-            isDrawing.current = false;
+          if (fabricRef.current) {
+            // disable the drawing mode of canvas
             fabricRef.current.isDrawingMode = false;
           }
-        }
+          break;
 
-        selectedShapeRef.current = elem?.value as string;
+        default:
+          if (fabricRef.current) {
+            if (elem && DRAWING_TOOLS.includes(elem.value)) {
+              isDrawing.current = true;
+              fabricRef.current.isDrawingMode = true;
 
-        break;
-    }
-  };
+              applyBrush(elem.value as 'freeform' | 'highlighter', fabricRef.current, currentColorRef);
+            } else {
+              isDrawing.current = false;
+              fabricRef.current.isDrawingMode = false;
+            }
+          }
+
+          selectedShapeRef.current = elem?.value as string;
+
+          break;
+      }
+    },
+    [elementAttributes.stroke, undo, redo, deleteAllShapes, deleteShapeFromStorage, syncShapeInStorage, onElement],
+  );
 
   useEffect(() => {
     if (!lastAction) return;
@@ -620,73 +623,41 @@ const CanvasContainerView = ({ screenshot, onElement }: CanvasContainerProps) =>
     });
 
     /**
-     * listen to the resize event on the window which is fired when the
-     * user resizes the window.
-     *
-     * We're using this to resize the canvas when the user resizes the
-     * window.
+     * Named handler refs so removeEventListener actually matches the addEventListener registration —
+     * previously inline arrows produced different function references and removal was a no-op,
+     * leaking handlers on every screenshot change.
      */
-    window.addEventListener('resize', () => {
+    const onWindowResize = () => {
       handleResize({
         canvas: fabricRef.current,
         backgroundImage: screenshot?.src ?? null,
       });
-    });
+    };
+    window.addEventListener('resize', onWindowResize);
 
-    /**
-     * listen to the key down event on the shadow dom which is fired when the
-     * user presses a key on the keyboard.
-     *
-     * We're using this to perform some actions like delete, copy, paste, etc when the user presses the respective keys on the keyboard.
-     */
     const shadowHost = getShadowHostElement();
     const shadow = shadowHost?.shadowRoot;
 
-    if (shadow) {
-      shadow.addEventListener('keydown', e => {
-        if (!(e instanceof KeyboardEvent) || !fabricRef.current) return;
-        handleKeyDown({
-          e,
-          canvas: fabricRef.current,
-          undo,
-          redo,
-          syncShapeInStorage,
-          deleteShapeFromStorage,
-        });
+    const onShadowKeyDown = (e: Event) => {
+      if (!(e instanceof KeyboardEvent) || !fabricRef.current) return;
+      handleKeyDown({
+        e,
+        canvas: fabricRef.current,
+        undo,
+        redo,
+        syncShapeInStorage,
+        deleteShapeFromStorage,
       });
+    };
+    if (shadow) {
+      shadow.addEventListener('keydown', onShadowKeyDown);
     }
 
-    // dispose the canvas and remove the event listeners when the component unmounts
     return () => {
-      /**
-       * dispose is a method provided by Fabric that allows you to dispose
-       * the canvas. It clears the canvas and removes all the event
-       * listeners
-       *
-       * dispose: http://fabricjs.com/docs/fabric.Canvas.html#dispose
-       */
       canvas.dispose();
-
-      // remove the event listeners
-      window.removeEventListener('resize', () => {
-        handleResize({
-          canvas: null,
-          backgroundImage: null,
-        });
-      });
-
+      window.removeEventListener('resize', onWindowResize);
       if (shadow) {
-        shadow.removeEventListener('keydown', e => {
-          if (!(e instanceof KeyboardEvent) || !fabricRef.current) return;
-          handleKeyDown({
-            e,
-            canvas: fabricRef.current,
-            undo,
-            redo,
-            syncShapeInStorage,
-            deleteShapeFromStorage,
-          });
-        });
+        shadow.removeEventListener('keydown', onShadowKeyDown);
       }
     };
   }, [screenshot?.id]); // run this effect only once when the component mounts and the canvasRef changes
@@ -756,26 +727,29 @@ const CanvasContainerView = ({ screenshot, onElement }: CanvasContainerProps) =>
     setActionMenuVisible(true);
   }, []);
 
-  const handleOnExportScreenshot = async (format: string = 'png') => {
-    const { objects, meta } = (await annotationsStorage.getAnnotations(screenshot.id!)) ?? {};
+  const handleOnExportScreenshot = useCallback(
+    async (format: string = 'png') => {
+      const { objects, meta } = (await annotationsStorage.getAnnotations(screenshot.id!)) ?? {};
 
-    const fileName = `${screenshot.name}.${format}`;
-    let file = null;
+      const fileName = `${screenshot.name}.${format}`;
+      let file = null;
 
-    const natural = meta?.sizes?.natural;
-    if (!objects?.length || !natural) {
-      file = await base64ToFile(screenshot.src, fileName);
-    } else {
-      file = await mergeScreenshot({
-        screenshot,
-        objects,
-        parentHeight: natural.height,
-        parentWidth: natural.width,
-      });
-    }
+      const natural = meta?.sizes?.natural;
+      if (!objects?.length || !natural) {
+        file = await base64ToFile(screenshot.src, fileName);
+      } else {
+        file = await mergeScreenshot({
+          screenshot,
+          objects,
+          parentHeight: natural.height,
+          parentWidth: natural.width,
+        });
+      }
 
-    saveAs(file, fileName);
-  };
+      saveAs(file, fileName);
+    },
+    [screenshot],
+  );
 
   const handleOnRemove = () => {
     handleActiveElement({ value: 'delete' } as any);

--- a/pages/content-ui/src/components/annotation-view/ui/toolbar.ui.tsx
+++ b/pages/content-ui/src/components/annotation-view/ui/toolbar.ui.tsx
@@ -126,7 +126,7 @@ const Toolbar = ({ activeElement, onActiveElement, onExport }: ToolbarProps) => 
   );
 };
 
-const arePropsEqual = (prevProps: ToolbarProps, nextProps: ToolbarProps) =>
-  prevProps.activeElement === nextProps.activeElement;
-
-export default memo(Toolbar, arePropsEqual);
+// Use React.memo's default shallow comparison: the previous custom comparator only checked
+// activeElement, so changes to onExport / onActiveElement (passed as plain inline functions from
+// the parent) were silently ignored — the toolbar could render with stale closure references.
+export default memo(Toolbar);

--- a/pages/content-ui/src/utils/annotation/canvas.util.ts
+++ b/pages/content-ui/src/utils/annotation/canvas.util.ts
@@ -220,9 +220,9 @@ export const handleCanvasMouseMove = ({
     default:
   }
 
-  // render objects on canvas
-  // renderAll: http://fabricjs.com/docs/fabric.Canvas.html#renderAll
-  canvas.renderAll();
+  // requestRenderAll coalesces multiple mouse:move calls into a single rAF tick; renderAll forces
+  // a synchronous immediate paint per call (dozens per second during fast drag).
+  canvas.requestRenderAll();
 
   // sync shape in storage
   if (shapeRef.current?.objectId) {
@@ -378,44 +378,38 @@ export const handleCanvasObjectScaling = ({ options, setElementAttributes }: Can
 };
 
 // render canvas objects coming from storage on canvas
-export const renderCanvas = ({ fabricRef, canvasObjects = [], activeObjectRef }: RenderCanvas) => {
+export const renderCanvas = async ({ fabricRef, canvasObjects = [], activeObjectRef }: RenderCanvas) => {
   // clear canvas
   fabricRef.current?.clear();
 
-  // render all objects on canvas
-  canvasObjects.forEach((objectData: any) => {
-    /**
-     * enlivenObjects() is used to render objects on canvas.
-     * It takes two arguments:
-     * 1. objectData: object data to render on canvas
-     * 2. callback: callback function to execute after rendering objects
-     * on canvas
-     *
-     * enlivenObjects: http://fabricjs.com/docs/fabric.util.html#.enlivenObjectEnlivables
-     */
-    fabricUtil.enlivenObjects<FabricObject>([objectData]).then(
-      (enlivenedObjects: FabricObject[]) => {
-        enlivenedObjects.forEach(enlivenedObj => {
-          // if element is active, keep it in active state so that it can be edited further
-          if (activeObjectRef.current?.objectId === objectData.objectId) {
-            fabricRef.current?.setActiveObject(enlivenedObj);
-          }
+  if (!canvasObjects.length) {
+    fabricRef.current?.renderAll();
+    return;
+  }
 
-          // add object to canvas
-          fabricRef.current?.add(enlivenedObj);
-        });
-      },
-      /**
-       * specify namespace of the object for fabric to render it on canvas
-       * A namespace is a string that is used to identify the type of
-       * object.
-       *
-       * Fabric Namespace: http://fabricjs.com/docs/fabric.html
-       */
-    );
-  });
+  /**
+   * enlivenObjects() rehydrates serialized objects into Fabric instances. Previously this was
+   * called once per object inside a forEach with an out-of-order `renderAll()` fired before any
+   * promise resolved — the canvas could flicker / show stale state, and each `.then` added objects
+   * one at a time, triggering an incremental paint per object.
+   *
+   * Now: a single enlivenObjects([all]) call, batch-add, single renderAll.
+   *
+   * enlivenObjects: http://fabricjs.com/docs/fabric.util.html#.enlivenObjectEnlivables
+   */
+  try {
+    const enlivenedObjects = await fabricUtil.enlivenObjects<FabricObject>(canvasObjects);
 
-  fabricRef.current?.renderAll();
+    enlivenedObjects.forEach((enlivenedObj, i) => {
+      const objectData = canvasObjects[i] as { objectId?: string };
+      if (objectData?.objectId && activeObjectRef.current?.objectId === objectData.objectId) {
+        fabricRef.current?.setActiveObject(enlivenedObj);
+      }
+      fabricRef.current?.add(enlivenedObj);
+    });
+  } finally {
+    fabricRef.current?.renderAll();
+  }
 };
 
 export const handleResize = ({


### PR DESCRIPTION
## Summary

Phase 6 of the refactor/performance roadmap. Annotation editor canvas hygiene + content-runtime re-injection safety.

### content-runtime
- `Root.tsx`: re-injection guard (id check) + `activeRoot` lifecycle tracking + `unmount()` + SPA-replace edge-case tear-down. Repeat injection was orphaning React trees (listeners, closures, subscriptions all leaked).
- `package.json`: removed unused `@extension/shared` / `@extension/storage` / `@extension/ui` dependencies.

### content-ui canvas
- `canvas.util.ts handleCanvasMouseMove`: `renderAll()` → `requestRenderAll()` (rAF-coalesced).
- `canvas.util.ts renderCanvas`: was per-object `enlivenObjects([single])` with a `renderAll` race; now batched via `await enlivenObjects(all)` + single trailing `renderAll`.
- `canvas-container.view.tsx`: window resize + shadow keydown listeners use named refs so `removeEventListener` actually matches.
- `canvas-container.view.tsx`: `handleActiveElement` and `handleOnExportScreenshot` wrapped in `useCallback`.
- `toolbar.ui.tsx`: dropped the custom `arePropsEqual` (only checked `activeElement` — silently dropped `onExport`/`onActiveElement` changes). With the parent's new `useCallback`s, default shallow memo now correctly prevents toolbar re-renders on canvas-mouse-event-driven parent renders.
- `package.json`: removed unused `moment` dependency.

## Test plan
- [x] `pnpm type-check` + `pnpm build:chrome:production` pass.
- [ ] Open annotation editor; draw freehand and shapes — interactions should feel smoother during fast drag (requestRenderAll).
- [ ] Switch screenshots in the editor; React Profiler should not show window/keydown listeners accumulating across screenshot changes.
- [ ] Open/close the editor several times; memory snapshot shouldn't grow per cycle.
- [ ] Export a screenshot with multiple annotations; verify it renders correctly (no partial/blank canvas from the renderCanvas race fix).
- [ ] On an SPA that re-injects content-runtime, confirm only one `#brie-runtime-root` is ever in the DOM.