### PR TITLE
perf(mic-permission, storage): cleanup leftovers [Phase 7]

### DIFF
--- a/packages/storage/lib/impl/theme.storage.ts
+++ b/packages/storage/lib/impl/theme.storage.ts
@@ -22,14 +22,19 @@ const applySystemTheme = () => {
   storage.set(() => systemTheme);
 };
 
-const listenToSystemThemeChanges = () => {
+/**
+ * Subscribe to system colour-scheme changes. Returns an unsubscribe function so callers can
+ * remove the matchMedia listener on teardown (previously it leaked for the lifetime of the page).
+ */
+const listenToSystemThemeChanges = (): (() => void) => {
   const mql = window.matchMedia('(prefers-color-scheme: dark)');
   mql.addEventListener('change', applySystemTheme);
+  return () => mql.removeEventListener('change', applySystemTheme);
 };
 
 export const themeStorage: ThemeStorage & {
   applySystemTheme: () => void;
-  listenToSystemThemeChanges: () => void;
+  listenToSystemThemeChanges: () => () => void;
 } = {
   ...storage,
   toggle: async () => {

--- a/pages/mic-permission/src/mic-permission.tsx
+++ b/pages/mic-permission/src/mic-permission.tsx
@@ -1,34 +1,78 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { recordingSettingsStorage } from '@extension/storage';
 import { Button, Icon } from '@extension/ui';
 
 type PageState = 'requesting' | 'granted' | 'denied' | 'error';
 
+const AUTO_CLOSE_DELAY_MS = 2000;
+
 export const MicPermission = () => {
   const [state, setState] = useState<PageState>('requesting');
   const extensionId = chrome.runtime.id;
+  const autoCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const requestInFlightRef = useRef(false);
 
   const requestPermission = useCallback(async () => {
+    // In-flight guard: rapid Try-Again clicks could race two requestPermission() invocations
+    // and end up scheduling two window.close() timers — one would fire orphaned.
+    if (requestInFlightRef.current) return;
+    requestInFlightRef.current = true;
+
+    // Cancel a pending auto-close from a previous completed attempt before starting a new one.
+    if (autoCloseTimerRef.current !== null) {
+      clearTimeout(autoCloseTimerRef.current);
+      autoCloseTimerRef.current = null;
+    }
+
     setState('requesting');
+
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      stream.getTracks().forEach(t => t.stop());
-      await recordingSettingsStorage.setMicPermission('granted');
-      setState('granted');
-      setTimeout(() => window.close(), 2000);
-    } catch (err: any) {
-      if (err?.name === 'NotAllowedError') {
-        await recordingSettingsStorage.setMicPermission('denied');
-        setState('denied');
-      } else {
-        setState('error');
+      // Pre-flight: if the browser already says permission is granted, skip the getUserMedia call
+      // entirely so we don't reacquire a hardware track just to immediately stop it.
+      try {
+        const status = await navigator.permissions?.query({ name: 'microphone' as PermissionName });
+        if (status?.state === 'granted') {
+          await recordingSettingsStorage.setMicPermission('granted');
+          setState('granted');
+          autoCloseTimerRef.current = setTimeout(() => window.close(), AUTO_CLOSE_DELAY_MS);
+          return;
+        }
+      } catch {
+        // navigator.permissions or the 'microphone' name may be unsupported (older Firefox);
+        // fall through to the regular getUserMedia path.
       }
+
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        stream.getTracks().forEach(t => t.stop());
+        await recordingSettingsStorage.setMicPermission('granted');
+        setState('granted');
+        autoCloseTimerRef.current = setTimeout(() => window.close(), AUTO_CLOSE_DELAY_MS);
+      } catch (err: unknown) {
+        if ((err as { name?: string })?.name === 'NotAllowedError') {
+          await recordingSettingsStorage.setMicPermission('denied');
+          setState('denied');
+        } else {
+          setState('error');
+        }
+      }
+    } finally {
+      // Clears on every exit path including the early return from the pre-flight branch.
+      requestInFlightRef.current = false;
     }
   }, []);
 
   useEffect(() => {
     requestPermission();
+
+    return () => {
+      // Clear any pending auto-close on unmount so it can't race a stale window reference.
+      if (autoCloseTimerRef.current !== null) {
+        clearTimeout(autoCloseTimerRef.current);
+        autoCloseTimerRef.current = null;
+      }
+    };
   }, [requestPermission]);
 
   return (


### PR DESCRIPTION
## Summary

Phase 7 (final) of the refactor/performance roadmap. Wraps up the smaller cleanup items the prior audits flagged.

### mic-permission
- `navigator.permissions.query` pre-flight: when state is already `'granted'`, skip `getUserMedia` entirely (avoids reacquiring a hardware audio track just to stop it).
- `setTimeout(() => window.close())` is now stored in a ref. Cleared on re-entry, on unmount, and on every async exit path via top-level `try/finally`.
- In-flight guard (`requestInFlightRef`): rapid Try-Again clicks no longer schedule two `window.close()` timers (one orphaned).
- Catch type narrowed from `any` to `unknown`.

### storage/theme
- `listenToSystemThemeChanges` now returns an unsubscribe function. Existing 3 callers (popup/content-ui/mic-permission index.tsx) discard the return; API is in place for follow-up cleanup.

## Test plan
- [x] `pnpm type-check` + `pnpm build:chrome:production` pass.
- [ ] Open mic-permission page after permission was granted previously — should immediately show 'granted' state without a re-prompt and auto-close after 2 s.
- [ ] Deny permission, then click 'Try again' rapidly. `window.close()` should not fire prematurely.
- [ ] Test in Firefox: page still works (graceful Permissions API fallback to `getUserMedia`).

## After this PR merges
This is the last phase PR. Next: smoke-test the full `refactor/performance` branch end-to-end, then open the final `refactor/performance` → `develop` PR.