### PR TITLE
fix: address 8 BLOCKING items from cross-section audit

### DIFF
--- a/chrome-extension/src/services/web-request.service.ts
+++ b/chrome-extension/src/services/web-request.service.ts
@@ -36,7 +36,12 @@ export const handleOnCompleted = (request: WebRequest.OnCompletedDetailsType) =>
       recordType: 'console',
       source: 'background',
       method: 'error',
-      args: [`[${request.type}] ${request.method} ${request.url} responded with status ${request.statusCode}`, request],
+      // Spread to a fresh object — the live `request` reference is bound to Chrome's webRequest
+      // dispatch; SW suspend/resume can mutate the backing memory between capture and serialization.
+      args: [
+        `[${request.type}] ${request.method} ${request.url} responded with status ${request.statusCode}`,
+        { ...request },
+      ],
       stackTrace: {
         parsed: 'interceptFetch',
         raw: '',

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "e2e": "pnpm zip && turbo e2e",
     "e2e:firefox": "pnpm zip:firefox && turbo e2e",
     "test:site": "pnpm build:chrome:production && pnpm -F @extension/e2e test:site",
-    "test:site:firefox": "pnpm build:firefox:production && pnpm -F @extension/e2e test:site",
     "lint": "turbo lint --continue",
     "lint:fix": "turbo lint:fix --continue",
     "format": "turbo format --continue -- --cache --cache-location node_modules/.cache/.prettiercache",

--- a/packages/storage/lib/base/base.ts
+++ b/packages/storage/lib/base/base.ts
@@ -138,6 +138,10 @@ export const createStorage = <D = string>(key: string, fallback: D, config?: Sto
   };
 
   get().then(data => {
+    // Guard against a set() that ran during the cold-start window and already wrote a value.
+    // Without this check, the stale get() result would clobber the in-memory cache, leaving
+    // React consumers showing the pre-write value until the next set() or liveUpdate fires.
+    if (initedCache) return;
     cache = data;
     initedCache = true;
     _emitChange();

--- a/pages/content-ui/src/App.tsx
+++ b/pages/content-ui/src/App.tsx
@@ -225,6 +225,7 @@ export default function App() {
                 screenshots={screenshots || []}
                 video={video}
                 events={events}
+                captureState={captureState}
                 onClose={handleOnClose}
                 onMinimize={handleOnMinimize}
                 onDeleteScreenshot={handleOnDeleteScreenshot}

--- a/pages/content-ui/src/components/annotation-view/canvas-container.view.tsx
+++ b/pages/content-ui/src/components/annotation-view/canvas-container.view.tsx
@@ -2,14 +2,9 @@ import type { Canvas, FabricObject, PencilBrush } from 'fabric';
 import { saveAs } from 'file-saver';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { CANVAS_ACTION, REWIND, sendRuntimeMessageToActiveTab, useStorage } from '@extension/shared';
+import { CANVAS_ACTION, REWIND, sendRuntimeMessageToActiveTab } from '@extension/shared';
 import type { Screenshot } from '@extension/shared';
-import {
-  annotationsHistoryStorage,
-  annotationsRedoStorage,
-  annotationsStorage,
-  captureStateStorage,
-} from '@extension/storage';
+import { annotationsHistoryStorage, annotationsRedoStorage, annotationsStorage } from '@extension/storage';
 import type { RootState } from '@extension/store';
 import { clearCanvasState, useAppDispatch, useAppSelector } from '@extension/store';
 import { Button, Icon } from '@extension/ui';
@@ -48,10 +43,11 @@ import {
 interface CanvasContainerProps {
   screenshot: Screenshot;
   onElement: (elem: ActiveElement) => void;
+  /** Provided by parent so this view doesn't double-subscribe to captureStateStorage. */
+  captureState: 'idle' | 'preparing' | 'capturing' | 'paused' | 'error' | 'unsaved';
 }
 
-const CanvasContainerView = ({ screenshot, onElement }: CanvasContainerProps) => {
-  const { state: captureState } = useStorage(captureStateStorage);
+const CanvasContainerView = ({ screenshot, onElement, captureState }: CanvasContainerProps) => {
   const { lastAction, tick } = useAppSelector((state: RootState) => state.canvasReducer);
   const dispatch = useAppDispatch();
 
@@ -160,28 +156,33 @@ const CanvasContainerView = ({ screenshot, onElement }: CanvasContainerProps) =>
    * useUndo and useRedo are hooks provided by local store that allow you to
    * undo and redo mutations.
    */
-  const restoreObjects = async (canvas: any, snapshot?: { objects?: any[] }) => {
-    const { meta } = (await annotationsStorage.getAnnotations(screenshot.id!)) ?? {};
+  // Stable refs so handleActiveElement (and the Toolbar memo downstream) doesn't re-create on
+  // every render. Without these, the canvas-container useCallback chain is defeated.
+  const restoreObjects = useCallback(
+    async (canvas: any, snapshot?: { objects?: any[] }) => {
+      const { meta } = (await annotationsStorage.getAnnotations(screenshot.id!)) ?? {};
 
-    if (!meta?.sizes?.fit) return;
+      if (!meta?.sizes?.fit) return;
 
-    const {
-      sizes: {
-        fit: { height, width },
-      },
-    } = meta as BackgroundFitMeta;
+      const {
+        sizes: {
+          fit: { height, width },
+        },
+      } = meta as BackgroundFitMeta;
 
-    if (snapshot) canvas.loadFromJSON({ objects: snapshot.objects });
+      if (snapshot) canvas.loadFromJSON({ objects: snapshot.objects });
 
-    await setCanvasBackground({
-      file: screenshot.src,
-      canvas,
-      parentWidth: width,
-      parentHeight: height,
-    });
-  };
+      await setCanvasBackground({
+        file: screenshot.src,
+        canvas,
+        parentWidth: width,
+        parentHeight: height,
+      });
+    },
+    [screenshot?.id, screenshot?.src],
+  );
 
-  const undo = async () => {
+  const undo = useCallback(async () => {
     const history = await undoAnnotation(screenshot.id!);
 
     if (history?.prevState && fabricRef.current) {
@@ -193,9 +194,9 @@ const CanvasContainerView = ({ screenshot, onElement }: CanvasContainerProps) =>
 
       await annotationsStorage.setAnnotations(screenshot.id!, { objects: canvasObjects.objects ?? [] });
     }
-  };
+  }, [screenshot?.id, restoreObjects]);
 
-  const redo = async () => {
+  const redo = useCallback(async () => {
     const history = await redoAnnotation(screenshot.id!);
 
     if (history?.restoredState && fabricRef.current) {
@@ -207,7 +208,7 @@ const CanvasContainerView = ({ screenshot, onElement }: CanvasContainerProps) =>
 
       await annotationsStorage.setAnnotations(screenshot.id!, { objects: canvasObjects.objects ?? [] });
     }
-  };
+  }, [screenshot?.id, restoreObjects]);
 
   /**
    * deleteShapeFromStorage is a mutation that deletes a shape from the

--- a/pages/content-ui/src/content.tsx
+++ b/pages/content-ui/src/content.tsx
@@ -50,6 +50,8 @@ interface ContentProps {
   screenshots: Screenshot[];
   video?: VideoSource;
   events?: eventWithTime[] | null;
+  /** Lifted from App.tsx so CanvasContainerView doesn't double-subscribe to captureStateStorage. */
+  captureState: 'idle' | 'preparing' | 'capturing' | 'paused' | 'error' | 'unsaved';
   onClose: () => void;
   onMinimize: () => void;
   onDeleteScreenshot: (id: string) => void;
@@ -65,6 +67,7 @@ const Content = ({
   activeScreenshotId,
   video,
   events,
+  captureState,
   onClose,
   onMinimize,
   onDeleteScreenshot,
@@ -479,6 +482,7 @@ const Content = ({
               <CanvasContainerView
                 key={activeScreenshotId ?? 'empty'}
                 screenshot={activeScreenshot!}
+                captureState={captureState}
                 onElement={handleOnElement}
               />
             )}

--- a/pages/content-ui/src/index.tsx
+++ b/pages/content-ui/src/index.tsx
@@ -25,7 +25,9 @@ if (navigator.userAgent.includes('Firefox')) {
    * Injecting styles into the document, this may cause style conflicts with the host page
    */
   const styleElement = document.createElement('style');
-  styleElement.innerHTML = tailwindcssOutput;
+  // Bundled CSS string from Vite's ?inline import — not untrusted input. textContent avoids the
+  // host page's strict-CSP rejecting innerHTML on style injection.
+  styleElement.textContent = tailwindcssOutput;
   shadowRoot.appendChild(styleElement);
 } else {
   /** Inject styles into shadow dom */

--- a/pages/content/src/interceptors/events/events.interceptor.ts
+++ b/pages/content/src/interceptors/events/events.interceptor.ts
@@ -367,9 +367,24 @@ let eventsInterceptorRegistered = false;
 const handleAllClicks = (event: MouseEvent) => {
   // Single early-exit on the extension-overlay path so all three handlers don't pay it independently.
   if (pathTouchesExtension(event)) return;
-  handleOnClick(event);
-  handleOnCustomSelectClick(event);
-  handleOnAriaToggleClick(event);
+  // Each handler is independently wrapped so a throw in one doesn't silently drop the others.
+  // Previously these were 3 separate addEventListener registrations — an exception in one had no
+  // effect on the others; the merged-listener refactor must preserve that behaviour.
+  try {
+    handleOnClick(event);
+  } catch (err) {
+    console.error('[brie] handleOnClick failed:', err);
+  }
+  try {
+    handleOnCustomSelectClick(event);
+  } catch (err) {
+    console.error('[brie] handleOnCustomSelectClick failed:', err);
+  }
+  try {
+    handleOnAriaToggleClick(event);
+  } catch (err) {
+    console.error('[brie] handleOnAriaToggleClick failed:', err);
+  }
 };
 
 /**

--- a/tests/e2e/playwright/non-interference.spec.ts
+++ b/tests/e2e/playwright/non-interference.spec.ts
@@ -11,6 +11,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 /**
  * Verifies the extension (a) reaches the target page and (b) doesn't break it.
  *
+ * Chromium only — Firefox's `firefox.launchPersistentContext` does not support `--load-extension`.
+ * Firefox extension testing requires an entirely different path (web-ext run / Marionette protocol)
+ * and is intentionally not wired into this spec.
+ *
  * Usage:
  *   TARGET_URL=https://your-site.com pnpm test:site
  *

--- a/tests/e2e/playwright/tsconfig.json
+++ b/tests/e2e/playwright/tsconfig.json
@@ -2,11 +2,11 @@
   "extends": "@extension/tsconfig/module",
   "compilerOptions": {
     "lib": ["dom"],
-    "types": ["node", "@wdio/globals/types", "@wdio/mocha-framework"],
+    "types": ["node"],
     "resolveJsonModule": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["specs", "config", "helpers"]
+  "include": ["**/*.ts"]
 }


### PR DESCRIPTION
## Summary

Follow-up to the 8 paranoid reviewers dispatched across the refactor/performance branch. This PR fixes all 8 items they classified as BLOCKING.

### Fixes

| # | File | What |
|---|---|---|
| 1 | \`pages/content-ui/src/index.tsx\` | Firefox \`<style>.innerHTML\` → \`textContent\`. Phase 6 fixed the same pattern in \`content-runtime/Root.tsx\` but missed this file. Strict-CSP host pages on Firefox previously broke silently. |
| 2 | \`pages/content-ui/.../canvas-container.view.tsx\` | Wrap \`undo\` / \`redo\` (and \`restoreObjects\`) in \`useCallback\`. They were churning every render → defeated \`handleActiveElement\`'s memo → defeated Phase 6's Toolbar memo. |
| 3 | \`pages/content-ui/.../canvas-container.view.tsx\` | Removed direct \`useStorage(captureStateStorage)\` subscription. Now passed as a prop from \`App.tsx\` via \`Content\`. Completes the Phase 4 dedup goal. |
| 4 | \`packages/storage/lib/base/base.ts\` | Module-load IIFE \`.then()\` now guards with \`if (!initedCache)\` so a concurrent \`set()\`'s value isn't clobbered by the stale \`get()\` result. |
| 5 | \`chrome-extension/src/services/web-request.service.ts\` | Spread \`{ ...request }\` in error-record \`args[1]\`. Phase 2's \`safeStructuredClone\` removal exposed the live reference. |
| 6 | \`pages/content/src/interceptors/events/events.interceptor.ts\` | Wrapped each of the 3 merged handlers in \`handleAllClicks\` in its own try/catch. Phase 3's merge regressed the per-listener isolation. |
| 7 | \`tests/e2e/playwright/tsconfig.json\` (NEW) | Playwright spec no longer compiles under wdio/mocha ambient types. |
| 8 | Root \`package.json\` | Removed \`test:site:firefox\` — it built Firefox but ran the chromium-only Playwright config. |

### Verified
- \`pnpm type-check\` passes.
- \`pnpm build:chrome:production\` + \`pnpm build:firefox:production\` succeed.
- \`pnpm test:site\` against example.com: 3/3 pass.
- \`pnpm test:site\` against drive.google.com: 3/3 pass.

### Out of scope (deferred)
The 11 WARNINGs from the same audit (i18n missing keys, content-ui matchMedia leak, mic-permission isMounted guard, screenshot \`cleanup()\` missing removals, dead \`renderCanvas\`, build-gate on test:site, etc.) are tracked but not addressed here.