### PR TITLE
chore: strip refactor-history comments added during refactor/performance

### DIFF
--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -22,10 +22,6 @@ runtime.onInstalled.addListener(handleOnInstalled);
 contextMenus.onClicked.addListener(handleOnContextMenuClicked);
 
 /**
- * Skip high-volume, low-signal types (images, fonts, media, ping, csp_report, other) — these
- * compounded the cost of every redaction pass without producing useful bug-capture data. Scripts
- * and stylesheets are kept so broken-asset 4xx/5xx errors are still reported.
- *
  * @todo
  * there is a scenario when tabId is -1,
  * but we know the requestId and we can use it to populate the right request data

--- a/chrome-extension/src/services/web-request.service.ts
+++ b/chrome-extension/src/services/web-request.service.ts
@@ -3,9 +3,6 @@ import type { WebRequest } from 'webextension-polyfill';
 import type { Record } from '@src/types';
 import { addOrMergeRecords } from '@src/utils';
 
-// Chrome passes plain serializable objects to webRequest handlers, so we can spread directly
-// without an extra structuredClone deep-copy on every event. The cast handles the polyfill type's
-// `bytes: unknown` shape (which is `ArrayBuffer` in practice for webRequest payloads).
 export const handleOnBeforeRequest = (request: WebRequest.OnBeforeRequestDetailsType) => {
   addOrMergeRecords(request.tabId, {
     recordType: 'network',
@@ -36,8 +33,6 @@ export const handleOnCompleted = (request: WebRequest.OnCompletedDetailsType) =>
       recordType: 'console',
       source: 'background',
       method: 'error',
-      // Spread to a fresh object — the live `request` reference is bound to Chrome's webRequest
-      // dispatch; SW suspend/resume can mutate the backing memory between capture and serialization.
       args: [
         `[${request.type}] ${request.method} ${request.url} responded with status ${request.statusCode}`,
         { ...request },

--- a/chrome-extension/src/utils/manage-records.util.ts
+++ b/chrome-extension/src/utils/manage-records.util.ts
@@ -7,21 +7,17 @@ import type { Record } from '@src/types';
 
 import { decodeRequestBody } from './decode-request-body.util';
 
-// Cache the skip list in memory. Refreshed via storage.subscribe so the cost is paid once per change,
-// not once per webRequest event (which fires hundreds of times per page load).
 let skipDomainsCache: string[] = [];
 
 const refreshSkipDomainsFromSnapshot = () => {
   skipDomainsCache = domainSkipListStorage.getSnapshot() ?? [];
 };
 
-// Prime the cache once, then keep it in sync via the storage subscriber (cheap, no async).
 void domainSkipListStorage.get().then(value => {
   skipDomainsCache = value ?? [];
 });
 domainSkipListStorage.subscribe(refreshSkipDomainsFromSnapshot);
 
-// Cap per-tab record count so a long browsing session can't grow the SW heap without bound.
 const MAX_RECORDS_PER_TAB = 5_000;
 const MAX_URL_MAP_PER_TAB = 1_000;
 
@@ -71,9 +67,6 @@ export const addOrMergeRecords = async (tabId: number, record: Record): Promise<
     return;
   }
 
-  // Use the in-memory skip list cache populated by domainSkipListStorage.subscribe.
-  // First call during SW boot may race the initial load and read [] — acceptable: redaction
-  // simply runs as if no domains were skip-listed for the first few requests.
   const skipDomains = skipDomainsCache;
   const tabUrl = record?.url || record?.pageUrl;
 
@@ -85,9 +78,6 @@ export const addOrMergeRecords = async (tabId: number, record: Record): Promise<
 
   const uuid = uuidv4();
 
-  // Drop the oldest entry once we know we'd otherwise grow the map (i.e. this is a brand-new
-  // insertion, not a merge into an existing recordKey). Eviction is performed inline at each
-  // insert site below so we never delete a key we're about to merge into.
   const evictOldestIfFull = () => {
     if (recordsMap.size >= MAX_RECORDS_PER_TAB) {
       const oldestKey = recordsMap.keys().next().value;
@@ -113,7 +103,6 @@ export const addOrMergeRecords = async (tabId: number, record: Record): Promise<
     let finalRequestId = requestId;
 
     if (type === 'xmlhttprequest' && requestId) {
-      // Bound the per-tab URL→requestId map (Map preserves insertion order, so this drops the oldest entry).
       if (urlMap.size >= MAX_URL_MAP_PER_TAB) {
         const oldestKey = urlMap.keys().next().value;
         if (oldestKey !== undefined) urlMap.delete(oldestKey);

--- a/chrome-extension/src/utils/rewind.util.ts
+++ b/chrome-extension/src/utils/rewind.util.ts
@@ -373,8 +373,6 @@ const ingestRewindEvents = async (tabId: number, events: unknown[]): Promise<voi
     return;
   }
 
-  // Below threshold: let the scheduled timer coalesce the write.
-  // Previously this path awaited flushTabToStorage AND scheduled a flush, defeating the debounce.
   scheduleFlushForTab(tabId);
 };
 

--- a/packages/shared/lib/constants/sensitive-keywords.constants.ts
+++ b/packages/shared/lib/constants/sensitive-keywords.constants.ts
@@ -1,5 +1,3 @@
-// Pre-compile a single case-insensitive regex per list — keyMatches runs on every key of every
-// network record, so the per-call `new RegExp(...)` cost was multiplied across thousands of calls.
 const buildListRegex = (list: string[]): RegExp =>
   new RegExp(`(^|[^a-z0-9])(?:${list.map(s => s.replace(/_/g, '[_-]?')).join('|')})([^a-z0-9]|$)`, 'i');
 

--- a/packages/storage/lib/base/base.ts
+++ b/packages/storage/lib/base/base.ts
@@ -100,8 +100,6 @@ export const createStorage = <D = string>(key: string, fallback: D, config?: Sto
     return deserialize(value[key] as string) ?? fallback;
   };
 
-  // Coalesce a burst of set() calls into a single listener notification per microtask. Multiple
-  // synchronous mutations now produce one re-render cycle instead of N.
   let notifyScheduled = false;
   const _emitChange = () => {
     if (notifyScheduled) return;
@@ -115,8 +113,6 @@ export const createStorage = <D = string>(key: string, fallback: D, config?: Sto
   const set = async (valueOrUpdate: ValueOrUpdate<D>) => {
     if (!initedCache) {
       cache = await get();
-      // Mark the cache initialised so subsequent set() calls don't each issue a redundant
-      // chrome.storage.get when the initial get().then() at module load hasn't resolved yet.
       initedCache = true;
     }
     cache = await updateCache(valueOrUpdate, cache);
@@ -138,9 +134,6 @@ export const createStorage = <D = string>(key: string, fallback: D, config?: Sto
   };
 
   get().then(data => {
-    // Guard against a set() that ran during the cold-start window and already wrote a value.
-    // Without this check, the stale get() result would clobber the in-memory cache, leaving
-    // React consumers showing the pre-write value until the next set() or liveUpdate fires.
     if (initedCache) return;
     cache = data;
     initedCache = true;

--- a/packages/storage/lib/impl/theme.storage.ts
+++ b/packages/storage/lib/impl/theme.storage.ts
@@ -22,10 +22,6 @@ const applySystemTheme = () => {
   storage.set(() => systemTheme);
 };
 
-/**
- * Subscribe to system colour-scheme changes. Returns an unsubscribe function so callers can
- * remove the matchMedia listener on teardown (previously it leaked for the lifetime of the page).
- */
 const listenToSystemThemeChanges = (): (() => void) => {
   const mql = window.matchMedia('(prefers-color-scheme: dark)');
   mql.addEventListener('change', applySystemTheme);

--- a/pages/content-runtime/src/Root.tsx
+++ b/pages/content-runtime/src/Root.tsx
@@ -9,18 +9,14 @@ const ROOT_ID = 'brie-runtime-root';
 let activeRoot: Root | null = null;
 
 export const mount = () => {
-  // Re-injection guard: if a previous mount() call already added the host element, do nothing.
-  // Without this, repeat injection (e.g. retry, SPA navigation) would create a second React tree
-  // and orphan the first — its event listeners, closures, and storage subscriptions all leak.
   if (document.getElementById(ROOT_ID)) return;
 
-  // SPA edge case: a previous activeRoot exists but its host element was nuked by a router that
-  // replaced document.body. Tear the old root down before creating a new one so we don't leak.
+  // SPA routers can replace document.body and detach our host element without unmounting React.
   if (activeRoot) {
     try {
       activeRoot.unmount();
     } catch {
-      // Best-effort; root may already be invalid.
+      // Root may already be invalid.
     }
     activeRoot = null;
   }
@@ -43,7 +39,6 @@ export const mount = () => {
      * Injecting styles into the document, this may cause style conflicts with the host page
      */
     const styleElement = document.createElement('style');
-    // Bundled CSS string from Vite's ?inline import — not untrusted input.
     styleElement.textContent = injectedStyle;
     shadowRoot.appendChild(styleElement);
   } else {

--- a/pages/content-ui/src/components/annotation-view/canvas-container.view.tsx
+++ b/pages/content-ui/src/components/annotation-view/canvas-container.view.tsx
@@ -43,7 +43,6 @@ import {
 interface CanvasContainerProps {
   screenshot: Screenshot;
   onElement: (elem: ActiveElement) => void;
-  /** Provided by parent so this view doesn't double-subscribe to captureStateStorage. */
   captureState: 'idle' | 'preparing' | 'capturing' | 'paused' | 'error' | 'unsaved';
 }
 
@@ -156,8 +155,6 @@ const CanvasContainerView = ({ screenshot, onElement, captureState }: CanvasCont
    * useUndo and useRedo are hooks provided by local store that allow you to
    * undo and redo mutations.
    */
-  // Stable refs so handleActiveElement (and the Toolbar memo downstream) doesn't re-create on
-  // every render. Without these, the canvas-container useCallback chain is defeated.
   const restoreObjects = useCallback(
     async (canvas: any, snapshot?: { objects?: any[] }) => {
       const { meta } = (await annotationsStorage.getAnnotations(screenshot.id!)) ?? {};
@@ -623,11 +620,6 @@ const CanvasContainerView = ({ screenshot, onElement, captureState }: CanvasCont
       // });
     });
 
-    /**
-     * Named handler refs so removeEventListener actually matches the addEventListener registration —
-     * previously inline arrows produced different function references and removal was a no-op,
-     * leaking handlers on every screenshot change.
-     */
     const onWindowResize = () => {
       handleResize({
         canvas: fabricRef.current,

--- a/pages/content-ui/src/components/annotation-view/ui/toolbar.ui.tsx
+++ b/pages/content-ui/src/components/annotation-view/ui/toolbar.ui.tsx
@@ -126,7 +126,4 @@ const Toolbar = ({ activeElement, onActiveElement, onExport }: ToolbarProps) => 
   );
 };
 
-// Use React.memo's default shallow comparison: the previous custom comparator only checked
-// activeElement, so changes to onExport / onActiveElement (passed as plain inline functions from
-// the parent) were silently ignored — the toolbar could render with stale closure references.
 export default memo(Toolbar);

--- a/pages/content-ui/src/content.tsx
+++ b/pages/content-ui/src/content.tsx
@@ -50,7 +50,6 @@ interface ContentProps {
   screenshots: Screenshot[];
   video?: VideoSource;
   events?: eventWithTime[] | null;
-  /** Lifted from App.tsx so CanvasContainerView doesn't double-subscribe to captureStateStorage. */
   captureState: 'idle' | 'preparing' | 'capturing' | 'paused' | 'error' | 'unsaved';
   onClose: () => void;
   onMinimize: () => void;

--- a/pages/content-ui/src/index.tsx
+++ b/pages/content-ui/src/index.tsx
@@ -25,8 +25,7 @@ if (navigator.userAgent.includes('Firefox')) {
    * Injecting styles into the document, this may cause style conflicts with the host page
    */
   const styleElement = document.createElement('style');
-  // Bundled CSS string from Vite's ?inline import — not untrusted input. textContent avoids the
-  // host page's strict-CSP rejecting innerHTML on style injection.
+  // textContent (not innerHTML) so strict-CSP host pages don't reject style injection.
   styleElement.textContent = tailwindcssOutput;
   shadowRoot.appendChild(styleElement);
 } else {

--- a/pages/content-ui/src/providers/annotations.provider.tsx
+++ b/pages/content-ui/src/providers/annotations.provider.tsx
@@ -15,11 +15,6 @@ type AnnotationsContextValue = {
 
 const AnnotationsContext = createContext<AnnotationsContextValue | null>(null);
 
-/**
- * Subscribes to the three annotation storages once and shares the result via context. Previous
- * implementation had Header, CanvasWrapper, and LeftSidebar each calling useStorage on the same
- * three storages, producing 3x listener calls + 3x re-render cycles per annotation write.
- */
 export const AnnotationsProvider = ({ children }: PropsWithChildren) => {
   const annotations = useStorage(annotationsStorage);
   const historyAnnotations = useStorage(annotationsHistoryStorage);

--- a/pages/content-ui/src/utils/annotation/canvas.util.ts
+++ b/pages/content-ui/src/utils/annotation/canvas.util.ts
@@ -220,8 +220,7 @@ export const handleCanvasMouseMove = ({
     default:
   }
 
-  // requestRenderAll coalesces multiple mouse:move calls into a single rAF tick; renderAll forces
-  // a synchronous immediate paint per call (dozens per second during fast drag).
+  // requestRenderAll coalesces rapid mouse:move events into one rAF tick (renderAll paints sync each call).
   canvas.requestRenderAll();
 
   // sync shape in storage
@@ -387,16 +386,7 @@ export const renderCanvas = async ({ fabricRef, canvasObjects = [], activeObject
     return;
   }
 
-  /**
-   * enlivenObjects() rehydrates serialized objects into Fabric instances. Previously this was
-   * called once per object inside a forEach with an out-of-order `renderAll()` fired before any
-   * promise resolved — the canvas could flicker / show stale state, and each `.then` added objects
-   * one at a time, triggering an incremental paint per object.
-   *
-   * Now: a single enlivenObjects([all]) call, batch-add, single renderAll.
-   *
-   * enlivenObjects: http://fabricjs.com/docs/fabric.util.html#.enlivenObjectEnlivables
-   */
+  // enlivenObjects: http://fabricjs.com/docs/fabric.util.html#.enlivenObjectEnlivables
   try {
     const enlivenedObjects = await fabricUtil.enlivenObjects<FabricObject>(canvasObjects);
 

--- a/pages/content/src/capture/rewind.capture.ts
+++ b/pages/content/src/capture/rewind.capture.ts
@@ -153,9 +153,6 @@ export const startRewindCapture = (): void => {
   if (!isRewindGloballyEnabled || !isCaptureAllowedForUrl) return;
   if (rrwebStopFunction) return;
 
-  // Stylesheet inlining and font collection serialize the entire page CSS / @font-face graph
-  // into the initial snapshot — megabytes on sites with large frameworks. Default to off and
-  // only enable when the user explicitly turned on rewind globally.
   rrwebStopFunction =
     record({
       emit: enqueueEvent,
@@ -213,14 +210,6 @@ export const restartRewindCapture = async (): Promise<{ ok: boolean; reason?: st
   return { ok: true };
 };
 
-/**
- * Detect SPA URL changes without polling.
- *
- * `historyApiInterceptor` (in interceptors/events/history.interceptor.ts) already monkey-patches
- * pushState/replaceState and dispatches `brie:url-changed` on every transition. We subscribe to
- * that broadcast plus `hashchange` (which the events interceptor does not handle) — no second
- * patch on history.* avoids stacking wrappers if either module is re-evaluated.
- */
 const startUrlWatcher = (): void => {
   const checkUrl = () => {
     const currentUrl = window.location.href;
@@ -239,9 +228,6 @@ const bootstrap = async (): Promise<void> => {
   startUrlWatcher();
 };
 
-// Defer bootstrap off the critical path. rewindSettingsStorage.isRewindEnabled() is async and
-// computeCapturePolicy() reads more storage; running this at idle keeps the host page's first
-// paint clean. Worst case: rrweb misses the earliest few events (acceptable — bootstrap is fast).
 const scheduleBootstrap = (): void => {
   type RIC = (cb: () => void, opts?: { timeout?: number }) => number;
   const ric = (window as unknown as { requestIdleCallback?: RIC }).requestIdleCallback;

--- a/pages/content/src/capture/screenshot.capture.ts
+++ b/pages/content/src/capture/screenshot.capture.ts
@@ -16,7 +16,6 @@ let dimensionLabel: HTMLDivElement;
 let message: HTMLDivElement | null = null;
 let loadingMessage: HTMLDivElement | null = null;
 
-// Named handler refs so cleanup() can actually removeEventListener.
 let selectionMouseUpHandler: ((e: MouseEvent) => void) | null = null;
 let selectionTouchEndHandler: ((e: TouchEvent) => void) | null = null;
 
@@ -233,9 +232,6 @@ const updateSelectionBox = (e: MouseEvent | TouchEvent) => {
 const onMouseDown = (e: MouseEvent | TouchEvent, mode: 'single' | 'multiple') => {
   if ('button' in e && e.button !== 0) return; // Only respond to left-click
 
-  // If a previous selection's handlers are still registered (e.g. user re-triggers screenshot
-  // before completing the first one), remove them before installing new ones. Otherwise the
-  // module-level refs get overwritten and the old listeners leak.
   if (selectionMouseUpHandler) {
     document.removeEventListener('mouseup', selectionMouseUpHandler);
     selectionMouseUpHandler = null;
@@ -259,8 +255,6 @@ const onMouseDown = (e: MouseEvent | TouchEvent, mode: 'single' | 'multiple') =>
   createSelectionBox();
   createDimensionLabel();
 
-  // updateSelectionBox does not call preventDefault, so passive: true preserves the browser's
-  // scroll-optimisation fast path. Named refs let cleanup() actually remove the up/end listeners.
   selectionMouseUpHandler = (ev: MouseEvent) => onMouseUp(ev, mode);
   selectionTouchEndHandler = (ev: TouchEvent) => onTouchEnd(ev, mode);
 

--- a/pages/content/src/interceptors/events/events.interceptor.ts
+++ b/pages/content/src/interceptors/events/events.interceptor.ts
@@ -84,7 +84,6 @@ const handleOnValueChange = (event: Event, reason: 'change' | 'blur' | 'input') 
  * @param event - Mouse click event.
  */
 const handleOnCustomSelectClick = (event: MouseEvent) => {
-  // pathTouchesExtension early-exit is handled once in handleAllClicks.
   const target = deepTarget(event);
 
   if (!target) return;
@@ -113,7 +112,6 @@ const handleOnCustomSelectClick = (event: MouseEvent) => {
  * @param event - Mouse click event.
  */
 const handleOnClick = (event: MouseEvent) => {
-  // pathTouchesExtension early-exit is handled once in handleAllClicks.
   const ep = document.elementFromPoint(event.clientX, event.clientY);
   const hitTarget = ep instanceof Element ? ep : deepTarget(event);
 
@@ -144,7 +142,6 @@ const handleOnClick = (event: MouseEvent) => {
  * Emits a single InputChange with inferred checked state.
  */
 const handleOnAriaToggleClick = (event: MouseEvent) => {
-  // pathTouchesExtension early-exit is handled once in handleAllClicks.
   const t = deepTarget(event);
   if (!(t instanceof HTMLElement)) return;
 
@@ -365,11 +362,8 @@ const createResizeOncePerActivity = (idleMs = 1000): ResizeHandler => {
 let eventsInterceptorRegistered = false;
 
 const handleAllClicks = (event: MouseEvent) => {
-  // Single early-exit on the extension-overlay path so all three handlers don't pay it independently.
   if (pathTouchesExtension(event)) return;
-  // Each handler is independently wrapped so a throw in one doesn't silently drop the others.
-  // Previously these were 3 separate addEventListener registrations — an exception in one had no
-  // effect on the others; the merged-listener refactor must preserve that behaviour.
+  // Each handler is independently wrapped so a throw in one doesn't drop the others.
   try {
     handleOnClick(event);
   } catch (err) {
@@ -422,7 +416,6 @@ export const interceptEvents = () => {
   // Inputs / selects changes
   document.addEventListener('change', e => handleOnValueChange(e, 'change'), { capture: true });
 
-  // Clicks, custom selects, and ARIA toggles share path/target derivation — merge into one listener.
   document.addEventListener('click', handleAllClicks, { capture: true });
 
   // Keyboard

--- a/pages/content/src/interceptors/events/history.interceptor.ts
+++ b/pages/content/src/interceptors/events/history.interceptor.ts
@@ -1,11 +1,7 @@
 import { AppEventType } from '@src/constants';
 import { sendEvent } from '@src/utils';
 
-/**
- * Custom event broadcast on every SPA URL transition (pushState / replaceState / popstate).
- * Other modules (e.g. rewind URL policy) can listen here instead of stacking their own
- * history.* monkey-patches on top of ours.
- */
+/** Dispatched on every SPA URL transition (pushState / replaceState / popstate). */
 const BRIE_URL_CHANGED_EVENT = 'brie:url-changed';
 
 let historyInterceptorInstalled = false;

--- a/pages/content/src/interceptors/index.ts
+++ b/pages/content/src/interceptors/index.ts
@@ -8,8 +8,6 @@ import { interceptFetch, interceptXHR } from './network';
  */
 const BLOCKED_DOMAINS = ['docs.google.com'];
 
-// Network and event interceptors must run before page scripts execute or events
-// will be missed. Console interception monkey-patches synchronously and is cheap.
 if (!BLOCKED_DOMAINS.includes(window.location.host)) {
   interceptFetch();
 }
@@ -18,8 +16,6 @@ interceptXHR();
 interceptConsole();
 interceptEvents();
 
-// Snapshot interceptors (cookies / localStorage / sessionStorage) iterate all keys at module load —
-// on pages with hundreds of keys this is synchronous work before first paint. Defer to idle.
 type RIC = (cb: () => void, opts?: { timeout?: number }) => number;
 const ric = (window as unknown as { requestIdleCallback?: RIC }).requestIdleCallback;
 const runSnapshotInterceptors = () => {

--- a/pages/content/src/interceptors/network/xhr.interceptor.ts
+++ b/pages/content/src/interceptors/network/xhr.interceptor.ts
@@ -45,9 +45,8 @@ export const interceptXHR = (): void => {
       this._requestDetails.requestBody = body || null;
     }
 
-    // Use addEventListener instead of replacing this.onreadystatechange. The previous code captured
-    // the page's handler at .send() time and re-invoked it after our work, but any code that
-    // assigns xhr.onreadystatechange AFTER calling .send() would be silently lost.
+    // Use addEventListener instead of replacing this.onreadystatechange — otherwise any handler
+    // the page assigns to xhr.onreadystatechange AFTER calling .send() is silently dropped.
     const onReadyStateChange = function (this: ExtendedXMLHttpRequest): void {
       if (this.readyState === 4 && this._requestDetails) {
         // Request completed

--- a/pages/content/src/utils/events/is-clickable.util.ts
+++ b/pages/content/src/utils/events/is-clickable.util.ts
@@ -16,9 +16,6 @@ export const isClickable = (el: Element | null): boolean => {
 
   if (role && ['button', 'link', 'menuitem', 'tab', 'option', 'switch'].includes(role)) return true;
 
-  // Inline handlers: any element with an `onclick` is treated as clickable.
-  // Previously a `cursor: pointer` check via getComputedStyle gated this, but the recalc cost on
-  // every click event was too high — accept slightly broader matching instead.
   if (typeof (el as unknown as { onclick?: unknown }).onclick === 'function') return true;
 
   return false;

--- a/pages/content/src/utils/events/is-interactive.util.ts
+++ b/pages/content/src/utils/events/is-interactive.util.ts
@@ -1,13 +1,8 @@
 /**
- * Determines whether an element is visible and interactable in layout.
- *
- * Uses non-zero bounding box as a cheap visibility proxy. The previous
- * `getComputedStyle` checks for `visibility`, `display`, and `pointer-events`
- * forced a style/layout recalc on every click — they're now skipped because a
- * zero-size bounding rect already covers the common hidden cases.
+ * Determines whether an element is visible in layout via a non-zero bounding box.
  *
  * @param el - The element to evaluate.
- * @returns True if visible and interactable; otherwise false.
+ * @returns True if visible; otherwise false.
  */
 const isVisibleBox = (el: Element): boolean => {
   const r = (el as HTMLElement).getBoundingClientRect?.();
@@ -33,8 +28,6 @@ const isHeuristicallyClickable = (el: HTMLElement): boolean => {
   const tabIndexAttr = el.getAttribute('tabindex');
   const tabIndex = tabIndexAttr !== null ? Number(tabIndexAttr) : undefined;
 
-  // Note: the `cursor === 'pointer'` check was removed — getComputedStyle on every click event
-  // forced a style/layout recalc. tabindex + ARIA attributes give us enough signal.
   if (tabIndex !== undefined && Number.isFinite(tabIndex) && tabIndex >= 0) return true;
 
   // Common interactive ARIA roles (covers many custom components)

--- a/pages/content/vite.config.mts
+++ b/pages/content/vite.config.mts
@@ -95,8 +95,6 @@ export default withPageConfig({
   publicDir: resolve(rootDir, 'public'),
   plugins: [selfContainedEntriesPlugin(), IS_DEV && makeEntryPointPlugin()],
   build: {
-    // selfContainedEntriesPlugin runs in `generateBundle` BEFORE the minifier — by then all imports
-    // have been inlined and the regex matching is already done, so production minify is safe.
     rollupOptions: {
       input: {
         index: resolve(rootDir, 'src/index.ts'),

--- a/pages/mic-permission/src/mic-permission.tsx
+++ b/pages/mic-permission/src/mic-permission.tsx
@@ -14,12 +14,10 @@ export const MicPermission = () => {
   const requestInFlightRef = useRef(false);
 
   const requestPermission = useCallback(async () => {
-    // In-flight guard: rapid Try-Again clicks could race two requestPermission() invocations
-    // and end up scheduling two window.close() timers — one would fire orphaned.
+    // Rapid Try-Again clicks could schedule two window.close() timers; one would fire orphaned.
     if (requestInFlightRef.current) return;
     requestInFlightRef.current = true;
 
-    // Cancel a pending auto-close from a previous completed attempt before starting a new one.
     if (autoCloseTimerRef.current !== null) {
       clearTimeout(autoCloseTimerRef.current);
       autoCloseTimerRef.current = null;
@@ -28,8 +26,6 @@ export const MicPermission = () => {
     setState('requesting');
 
     try {
-      // Pre-flight: if the browser already says permission is granted, skip the getUserMedia call
-      // entirely so we don't reacquire a hardware track just to immediately stop it.
       try {
         const status = await navigator.permissions?.query({ name: 'microphone' as PermissionName });
         if (status?.state === 'granted') {
@@ -39,8 +35,7 @@ export const MicPermission = () => {
           return;
         }
       } catch {
-        // navigator.permissions or the 'microphone' name may be unsupported (older Firefox);
-        // fall through to the regular getUserMedia path.
+        // navigator.permissions / 'microphone' name unsupported on older Firefox; fall through.
       }
 
       try {
@@ -58,7 +53,6 @@ export const MicPermission = () => {
         }
       }
     } finally {
-      // Clears on every exit path including the early return from the pre-flight branch.
       requestInFlightRef.current = false;
     }
   }, []);
@@ -67,7 +61,6 @@ export const MicPermission = () => {
     requestPermission();
 
     return () => {
-      // Clear any pending auto-close on unmount so it can't race a stale window reference.
       if (autoCloseTimerRef.current !== null) {
         clearTimeout(autoCloseTimerRef.current);
         autoCloseTimerRef.current = null;

--- a/pages/popup/src/components/capture/capture-content.view.tsx
+++ b/pages/popup/src/components/capture/capture-content.view.tsx
@@ -32,7 +32,6 @@ import { CaptureScreenshotView, CaptureSessionView, RecordVideoView } from './vi
 
 type CaptureContentViewProps = {
   onActiveTabChange: (id: number | null) => void;
-  /** Provided by parent so we don't double-subscribe to captureStateStorage. */
   captureState: CaptureState;
 };
 
@@ -254,6 +253,4 @@ const CaptureContentViewInner = ({ onActiveTabChange, captureState }: CaptureCon
   );
 };
 
-// Memoized so a parent re-render that produces the same captureState/onActiveTabChange refs
-// doesn't cascade through this view. Pair with the stable refs in popup-content.tsx.
 export const CaptureContentView = memo(CaptureContentViewInner);

--- a/pages/popup/src/components/slices-history/content.slices-history.tsx
+++ b/pages/popup/src/components/slices-history/content.slices-history.tsx
@@ -78,8 +78,6 @@ export const SlicesHistoryContent = ({ onBack }: { onBack: () => void }) => {
   const [deleteSliceByExternalId, { isLoading: isDeleteSliceLoading }] = useDeleteSliceByIdMutation();
   const { isLoading, data: slices } = useGetSlicesQuery({ ...pagination, ...filters });
 
-  // Read totalToday from the same query that powers this list — no need for the parallel
-  // useGetSlicesQuery({ limit: 1, take: 10 }) call in useSlicesCreatedToday when we're on this view.
   const totalSlicesCreatedToday = slices?.totalToday ?? 0;
 
   const onDelete = useCallback(
@@ -136,9 +134,7 @@ export const SlicesHistoryContent = ({ onBack }: { onBack: () => void }) => {
                 isDeleteLoading={isDeleteSliceLoading}
                 onDelete={onDelete}
               />
-              {/* Visible-list separator: use items.length, not slices.total (which counts the full
-                  dataset, not just this page). Previously rendered a trailing separator on every
-                  page except the very last one of the entire dataset. */}
+              {/* slices.total is the full dataset count, not this page — use items.length. */}
               {idx !== slices.items.length - 1 && <Separator className="h-px bg-gray-900/5 dark:bg-gray-800" />}
             </Fragment>
           ))}

--- a/pages/popup/src/hooks/use-auth-state.hook.ts
+++ b/pages/popup/src/hooks/use-auth-state.hook.ts
@@ -29,8 +29,7 @@ type HealthCache = { ok: boolean; checkedAt: number };
 const fetchHealth = async (signal: AbortSignal): Promise<boolean> => {
   if (!API_BASE_URL) return false;
 
-  // The outer controller aborts on component unmount / new run; this inner controller adds a
-  // bounded timeout so a hung network call doesn't strand the user on `api_unavailable` forever.
+  // Inner controller adds a bounded timeout so a hung request doesn't strand the user.
   const timeoutController = new AbortController();
   const timeoutId = setTimeout(() => timeoutController.abort(), HEALTH_FETCH_TIMEOUT_MS);
   const onParentAbort = () => timeoutController.abort();
@@ -86,8 +85,6 @@ const useAuthState = (): AuthState => {
 
   const { data: user, isLoading, isError, error } = useGetUserDetailsQuery(undefined, { skip: skipUserQuery });
 
-  // Health check on mount + retry. Uses chrome.storage.session as a 30s SWR cache so reopening the
-  // popup doesn't gate first paint on a network round-trip.
   const runHealthCheck = useCallback(async (options?: { skipCache?: boolean }) => {
     abortRef.current?.abort();
     const controller = new AbortController();
@@ -98,8 +95,6 @@ const useAuthState = (): AuthState => {
     if (controller.signal.aborted) return;
 
     if (cached) {
-      // Render immediately from cache, then revalidate in the background. Surfaces stale failure
-      // states via revalidation rather than blocking.
       if (cached.ok) {
         setHealthPassed(true);
       } else {
@@ -131,7 +126,6 @@ const useAuthState = (): AuthState => {
     };
   }, [runHealthCheck]);
 
-  // Derive phase from health + tokens + query state
   useEffect(() => {
     if (!healthPassed) return;
 
@@ -140,7 +134,6 @@ const useAuthState = (): AuthState => {
       return;
     }
 
-    // Waiting for initial user fetch
     if (isLoading) {
       setPhase('checking_auth');
       return;
@@ -167,7 +160,6 @@ const useAuthState = (): AuthState => {
   }, [healthPassed, hasTokens, isLoading, isError, error, user]);
 
   const retry = useCallback(() => {
-    // User-initiated retry bypasses cache.
     runHealthCheck({ skipCache: true });
   }, [runHealthCheck]);
 

--- a/pages/popup/src/index.tsx
+++ b/pages/popup/src/index.tsx
@@ -16,9 +16,6 @@ const init = () => {
   }
   const root = createRoot(appContainer);
 
-  // Hoisted out of <Popup/> so the Redux provider doesn't sit inside the theme-reactive render
-  // path. Theme changes triggered a re-render of Popup which previously rerendered ReduxProvider
-  // and every descendant.
   root.render(
     <ReduxProvider store={store}>
       <Popup />

--- a/pages/popup/src/popup-content.tsx
+++ b/pages/popup/src/popup-content.tsx
@@ -61,8 +61,6 @@ export const PopupContent = ({
   }, [totalSlicesCreatedToday, user?.authMethod, activeTab.id]);
 
   useEffect(() => {
-    // Fire the storage read and tab query in parallel — previously the active-tab URL would only
-    // arrive after a second async tick, causing flicker between guards (internal page, unsaved-tab).
     const initializeState = async () => {
       const tab = await getActiveTab();
       setActiveTab(prev => ({

--- a/pages/popup/src/providers/auth-state.provider.tsx
+++ b/pages/popup/src/providers/auth-state.provider.tsx
@@ -9,8 +9,6 @@ const AuthStateContext = createContext<AuthState | null>(null);
 export const AuthStateProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const authState = useAuthState();
 
-  // Memoize the context value so consumers don't re-render on every Provider render — only when
-  // one of phase / user / retry actually changes.
   const value = useMemo(
     () => authState,
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/tests/e2e/playwright/non-interference.spec.ts
+++ b/tests/e2e/playwright/non-interference.spec.ts
@@ -9,21 +9,10 @@ import type { BrowserContext } from '@playwright/test';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /**
- * Verifies the extension (a) reaches the target page and (b) doesn't break it.
+ * Chromium only — Firefox's `firefox.launchPersistentContext` does not support `--load-extension`;
+ * Firefox extension testing needs web-ext / Marionette and is intentionally not wired into this spec.
  *
- * Chromium only — Firefox's `firefox.launchPersistentContext` does not support `--load-extension`.
- * Firefox extension testing requires an entirely different path (web-ext run / Marionette protocol)
- * and is intentionally not wired into this spec.
- *
- * Usage:
- *   TARGET_URL=https://your-site.com pnpm test:site
- *
- * Defaults to example.com so the spec stays self-contained for CI.
- *
- * Why Playwright instead of WebdriverIO: chromedriver in Chrome 130+ silently drops
- * --load-extension and the `extensions` capability for MV3 extensions, so wdio specs run
- * against a host page with no extension injected. Playwright's launchPersistentContext path
- * loads MV3 extensions correctly.
+ * Usage: TARGET_URL=https://your-site.com pnpm test:site (defaults to example.com).
  */
 
 const TARGET_URL = process.env.TARGET_URL ?? 'https://www.example.com';

--- a/tests/e2e/playwright/playwright.config.ts
+++ b/tests/e2e/playwright/playwright.config.ts
@@ -1,12 +1,9 @@
 import { defineConfig } from '@playwright/test';
 
 /**
- * Playwright config focused on extension-injection tests.
- *
  * MV3 extensions require persistent-context Chromium, which doesn't compose with Playwright's
- * standard `page` fixture — each spec creates its own context. Workers are forced to 1 so a
- * single shared user-data-dir is used per run (concurrent persistent contexts conflict on the
- * same profile path).
+ * standard `page` fixture — each spec creates its own context. `workers: 1` because concurrent
+ * persistent contexts conflict on the same user-data-dir path.
  */
 export default defineConfig({
   testDir: '.',


### PR DESCRIPTION
## Summary

Seven simplifier agents dispatched in parallel across non-overlapping file sets removed comments that explained WHAT the code does, restated obvious patterns, or read like commit messages (\"Previously...\", \"Was...\", \"Refactor history...\").

### Kept comments fall into these buckets
- **Cross-browser support gaps** — Firefox lacks \`chrome.storage.session\`, MV3 extensions don't load in old headless, etc.
- **Subtle bug-prevention** — XHR \`addEventListener\` vs \`onreadystatechange\` (pages assigning the handler after \`.send()\` get dropped otherwise); merged-click-handler try/catch (one throw shouldn't drop the other two).
- **Hidden constraints that would surprise a reader** — strict-CSP rejecting \`innerHTML\`, longtask observer unsupported on some engines, SPA routers replacing \`document.body\`.
- **Public-API contracts** — \`BRIE_URL_CHANGED_EVENT\` dispatch semantics, \`interceptEvents\` idempotency guard.

### Stats
- 32 files touched
- −159 / +20 lines (net −139 lines of comment noise)

### Verified
- \`pnpm type-check\` passes.
- \`pnpm build:chrome:production\` succeeds.

No behavior change — comments only.