### PR TITLE
fix(i18n): add 4 missing keys to all non-EN locales [W-1]

### DIFF
--- a/packages/i18n/locales/es/messages.json
+++ b/packages/i18n/locales/es/messages.json
@@ -573,5 +573,17 @@
   },
   "noDomains": {
     "message": "Aún no se han agregado dominios. La información sensible solo se omite en localhost por defecto."
+  },
+  "noCaptureData": {
+    "message": "No capture data available. Start a recording first."
+  },
+  "emptyResultFallback": {
+    "message": "No suggestion could be generated. Try again."
+  },
+  "noStepsFound": {
+    "message": "No steps could be reproduced from the captured session."
+  },
+  "outputTruncated": {
+    "message": "The generated text was cut off. Try with fewer steps."
   }
 }

--- a/packages/i18n/locales/fil/messages.json
+++ b/packages/i18n/locales/fil/messages.json
@@ -573,5 +573,17 @@
   },
   "noDomains": {
     "message": "Wala pang naidagdag na domain. Ang sensitibong impormasyon ay nili-laktawan lang sa localhost bilang default."
+  },
+  "noCaptureData": {
+    "message": "No capture data available. Start a recording first."
+  },
+  "emptyResultFallback": {
+    "message": "No suggestion could be generated. Try again."
+  },
+  "noStepsFound": {
+    "message": "No steps could be reproduced from the captured session."
+  },
+  "outputTruncated": {
+    "message": "The generated text was cut off. Try with fewer steps."
   }
 }

--- a/packages/i18n/locales/hi/messages.json
+++ b/packages/i18n/locales/hi/messages.json
@@ -573,5 +573,17 @@
   },
   "noDomains": {
     "message": "अभी तक कोई डोमेन नहीं जोड़ा गया। संवेदनशील जानकारी डिफ़ॉल्ट रूप से केवल localhost पर छोड़ी जाती है।"
+  },
+  "noCaptureData": {
+    "message": "No capture data available. Start a recording first."
+  },
+  "emptyResultFallback": {
+    "message": "No suggestion could be generated. Try again."
+  },
+  "noStepsFound": {
+    "message": "No steps could be reproduced from the captured session."
+  },
+  "outputTruncated": {
+    "message": "The generated text was cut off. Try with fewer steps."
   }
 }

--- a/packages/i18n/locales/it/messages.json
+++ b/packages/i18n/locales/it/messages.json
@@ -573,5 +573,17 @@
   },
   "noDomains": {
     "message": "Nessun dominio aggiunto. Le informazioni sensibili vengono saltate solo su localhost per impostazione predefinita."
+  },
+  "noCaptureData": {
+    "message": "No capture data available. Start a recording first."
+  },
+  "emptyResultFallback": {
+    "message": "No suggestion could be generated. Try again."
+  },
+  "noStepsFound": {
+    "message": "No steps could be reproduced from the captured session."
+  },
+  "outputTruncated": {
+    "message": "The generated text was cut off. Try with fewer steps."
   }
 }

--- a/packages/i18n/locales/ro/messages.json
+++ b/packages/i18n/locales/ro/messages.json
@@ -573,5 +573,17 @@
   },
   "noDomains": {
     "message": "Niciun domeniu adăugat încă. Informațiile sensibile sunt omise doar pe localhost în mod implicit."
+  },
+  "noCaptureData": {
+    "message": "No capture data available. Start a recording first."
+  },
+  "emptyResultFallback": {
+    "message": "No suggestion could be generated. Try again."
+  },
+  "noStepsFound": {
+    "message": "No steps could be reproduced from the captured session."
+  },
+  "outputTruncated": {
+    "message": "The generated text was cut off. Try with fewer steps."
   }
 }

--- a/packages/i18n/locales/ru/messages.json
+++ b/packages/i18n/locales/ru/messages.json
@@ -573,5 +573,17 @@
   },
   "noDomains": {
     "message": "Домены ещё не добавлены. Конфиденциальная информация пропускается только на localhost по умолчанию."
+  },
+  "noCaptureData": {
+    "message": "No capture data available. Start a recording first."
+  },
+  "emptyResultFallback": {
+    "message": "No suggestion could be generated. Try again."
+  },
+  "noStepsFound": {
+    "message": "No steps could be reproduced from the captured session."
+  },
+  "outputTruncated": {
+    "message": "The generated text was cut off. Try with fewer steps."
   }
 }

--- a/packages/i18n/locales/uk/messages.json
+++ b/packages/i18n/locales/uk/messages.json
@@ -573,5 +573,17 @@
   },
   "noDomains": {
     "message": "Домени ще не додано. Конфіденційна інформація пропускається лише на localhost за замовчуванням."
+  },
+  "noCaptureData": {
+    "message": "No capture data available. Start a recording first."
+  },
+  "emptyResultFallback": {
+    "message": "No suggestion could be generated. Try again."
+  },
+  "noStepsFound": {
+    "message": "No steps could be reproduced from the captured session."
+  },
+  "outputTruncated": {
+    "message": "The generated text was cut off. Try with fewer steps."
   }
 }


### PR DESCRIPTION
## Summary

\`es\`, \`fil\`, \`hi\`, \`it\`, \`ro\`, \`ru\`, and \`uk\` were missing the 4 keys used by the Right Sidebar AI-generation flow: \`noCaptureData\`, \`emptyResultFallback\`, \`noStepsFound\`, \`outputTruncated\`.

Firefox doesn't auto-fall-back to \`en\` for missing \`chrome.i18n\` keys → non-EN Firefox users saw blank strings.

Populates each locale with the EN copy. Native-speaker translation is a follow-up; this PR's only job is to stop the blank-string regression.

Tech-debt entry W-1 in \`docs/TECH_DEBT.md\`.

## Verified
- \`pnpm --filter @extension/i18n ready\` (regenerates the typed key union)
- \`pnpm type-check\` passes