### PR TITLE
fix(content-ui): release matchMedia listener on pagehide [W-2]

### DIFF
--- a/pages/content-ui/src/index.tsx
+++ b/pages/content-ui/src/index.tsx
@@ -37,7 +37,12 @@ if (navigator.userAgent.includes('Firefox')) {
 
 // Apply the system theme via the storage API
 themeStorage.applySystemTheme();
-themeStorage.listenToSystemThemeChanges();
+const unsubscribeFromThemeChanges = themeStorage.listenToSystemThemeChanges();
+
+// SPA routers that nuke document.body trigger pagehide on the old document, then re-inject the
+// content-ui. Without this unsubscribe, every re-injection added another matchMedia listener on
+// the same MediaQueryList — two notifications per theme change, two redundant storage writes.
+window.addEventListener('pagehide', unsubscribeFromThemeChanges, { once: true });
 
 shadowRoot.appendChild(rootIntoShadow);
 createRoot(rootIntoShadow).render(<App />);


### PR DESCRIPTION
## Summary

\`themeStorage.listenToSystemThemeChanges()\` returns an unsubscribe (added in the perf branch) but \`pages/content-ui/src/index.tsx\` discarded it. On SPA routers that nuke \`document.body\` and re-inject the content-ui, every cycle added another \`matchMedia\` listener on the same MediaQueryList — two notifications per theme change, two redundant storage writes.

Capture the unsubscribe and fire it from a \`pagehide\` listener.

Tech-debt entry W-2 in \`docs/TECH_DEBT.md\`.

## Verified
- \`pnpm type-check\` passes.
- \`pnpm build:chrome:production\` succeeds.