### PR TITLE
fix(content/capture): remove instruction-phase move listeners in cleanup [W-4]

### DIFF
--- a/pages/content/src/capture/screenshot.capture.ts
+++ b/pages/content/src/capture/screenshot.capture.ts
@@ -666,6 +666,11 @@ export const cleanup = (): void => {
   document.body.style.overflow = '';
   document.removeEventListener('keydown', onKeyDown);
   document.removeEventListener('mousemove', updateSelectionBox);
+  // Also remove the cursor-tracking listeners attached by showInstructions(). Without these the
+  // listeners stayed on document for the page's lifetime after ESC/completion — each cancelled
+  // capture session leaked another pair.
+  document.removeEventListener('mousemove', onMouseMove);
+  document.removeEventListener('touchmove', onTouchMove);
   if (selectionMouseUpHandler) {
     document.removeEventListener('mouseup', selectionMouseUpHandler);
     selectionMouseUpHandler = null;


### PR DESCRIPTION
## Summary

\`showInstructions()\` registers \`onMouseMove\` / \`onTouchMove\` on document so the instruction tooltip can follow the cursor. \`cleanup()\` only removed the \`updateSelectionBox\` listeners — the two instruction-phase listeners stayed on document for the page lifetime after ESC or completion. Each cancelled capture leaked another pair, with the closures retaining DOM nodes.

Add the two \`removeEventListener\` calls inside \`cleanup()\`.

Tech-debt entry W-4 in \`docs/TECH_DEBT.md\`.

## Verified
- \`pnpm type-check\` passes.
- \`pnpm build:chrome:production\` succeeds.