### PR TITLE
chore(content-ui): drop dead renderCanvas export [W-5]

### DIFF
--- a/pages/content-ui/src/models/annotation.model.ts
+++ b/pages/content-ui/src/models/annotation.model.ts
@@ -201,12 +201,6 @@ export type CanvasObjectScaling = {
   setElementAttributes: Dispatch<SetStateAction<Attributes>>;
 };
 
-export type RenderCanvas = {
-  fabricRef: RefObject<Canvas | null>;
-  canvasObjects: any;
-  activeObjectRef: any;
-};
-
 export type CursorChatProps = {
   cursor: { x: number; y: number };
   cursorState: CursorState;

--- a/pages/content-ui/src/utils/annotation/canvas.util.ts
+++ b/pages/content-ui/src/utils/annotation/canvas.util.ts
@@ -1,4 +1,4 @@
-import { Canvas, FabricObject, PencilBrush, util as fabricUtil, Point } from 'fabric';
+import { Canvas, FabricObject, PencilBrush, Point } from 'fabric';
 import type { RefObject } from 'react';
 import { v4 as uuid4 } from 'uuid';
 
@@ -11,7 +11,6 @@ import type {
   CanvasObjectScaling,
   CanvasPathCreated,
   CanvasSelectionCreated,
-  RenderCanvas,
 } from '@src/models';
 
 import { getCanvasScale } from './canvas-scale.utils';
@@ -374,32 +373,6 @@ export const handleCanvasObjectScaling = ({ options, setElementAttributes }: Can
     width: scaledWidth?.toFixed(0).toString() || '',
     height: scaledHeight?.toFixed(0).toString() || '',
   }));
-};
-
-// render canvas objects coming from storage on canvas
-export const renderCanvas = async ({ fabricRef, canvasObjects = [], activeObjectRef }: RenderCanvas) => {
-  // clear canvas
-  fabricRef.current?.clear();
-
-  if (!canvasObjects.length) {
-    fabricRef.current?.renderAll();
-    return;
-  }
-
-  // enlivenObjects: http://fabricjs.com/docs/fabric.util.html#.enlivenObjectEnlivables
-  try {
-    const enlivenedObjects = await fabricUtil.enlivenObjects<FabricObject>(canvasObjects);
-
-    enlivenedObjects.forEach((enlivenedObj, i) => {
-      const objectData = canvasObjects[i] as { objectId?: string };
-      if (objectData?.objectId && activeObjectRef.current?.objectId === objectData.objectId) {
-        fabricRef.current?.setActiveObject(enlivenedObj);
-      }
-      fabricRef.current?.add(enlivenedObj);
-    });
-  } finally {
-    fabricRef.current?.renderAll();
-  }
 };
 
 export const handleResize = ({

--- a/pages/content-ui/src/utils/annotation/index.ts
+++ b/pages/content-ui/src/utils/annotation/index.ts
@@ -10,7 +10,6 @@ export {
   handleCanvasObjectMoving,
   handleCanvasSelectionCreated,
   handleCanvasObjectScaling,
-  renderCanvas,
   handleResize,
   handleCanvasZoom,
 } from './canvas.util';


### PR DESCRIPTION
## Summary

Phase 6 rewrote \`renderCanvas\` to use batched \`fabricUtil.enlivenObjects\` followed by a single \`renderAll()\`. Right idea — but the function had no callers at that point (\`canvas-container.view.tsx\` had already moved to \`restoreObjects\` / \`loadFromJSON\`), so the rewrite landed in dead code.

Leaves an async surface where any future caller that forgot \`.catch()\` would silently swallow rejections.

Deleting it (vs. wiring it back in) is the lower-risk option — the calling pattern has shifted and there's no current spec to validate against.

### Removed
- \`renderCanvas\` impl in \`pages/content-ui/src/utils/annotation/canvas.util.ts\`.
- \`renderCanvas\` re-export from the \`annotation/index\` barrel.
- \`RenderCanvas\` type from \`pages/content-ui/src/models/annotation.model.ts\`.
- The now-unused \`fabricUtil\` import (only \`renderCanvas\` used it in this file; \`enlivenObjects\` is still imported separately in \`merge-screenshot.util.ts\`).

Tech-debt entry W-5 in \`docs/TECH_DEBT.md\`.

## Verified
- \`pnpm type-check\` passes.
- \`pnpm build:chrome:production\` succeeds.