### PR TITLE
chore: strip slop comments across the repo

### DIFF
--- a/chrome-extension/manifest.ts
+++ b/chrome-extension/manifest.ts
@@ -2,29 +2,11 @@ import { readFileSync } from 'node:fs';
 
 const packageJson = JSON.parse(readFileSync('./package.json', 'utf8'));
 
-/**
- * @prop default_locale
- * if you want to support multiple languages, you can use the following reference
- * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Internationalization
- *
- * @prop browser_specific_settings
- * Must be unique to your extension to upload to addons.mozilla.org
- * (you can delete if you only want a chrome extension)
- *
- * @prop permissions
- * Firefox doesn't support sidePanel (It will be deleted in manifest parser)
- *
- * @prop content_scripts
- * css: ['content.css'], // public folder
- */
 const manifest = {
   manifest_version: 3,
   default_locale: 'en',
   name: '__MSG_extensionName__',
   browser_specific_settings: {
-    /**
-     * @todo add it to env
-     */
     gecko: {
       id: 'ion.leu@gmail.com',
       strict_min_version: '109.0',

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -21,13 +21,6 @@ runtime.onMessage.addListener(handleOnMessage);
 runtime.onInstalled.addListener(handleOnInstalled);
 contextMenus.onClicked.addListener(handleOnContextMenuClicked);
 
-/**
- * @todo
- * there is a scenario when tabId is -1,
- * but we know the requestId and we can use it to populate the right request data
- *
- * related to all 3 web req states
- */
 const TRACKED_REQUEST_TYPES: WebRequest.ResourceType[] = [
   'main_frame',
   'sub_frame',

--- a/chrome-extension/src/services/badge.service.ts
+++ b/chrome-extension/src/services/badge.service.ts
@@ -29,7 +29,6 @@ export const initBadgeListener = () => {
   let tabId: number | null = null;
   let color = '';
 
-  // Restore badge state on startup
   chrome.storage.local.get([CAPTURE_STATE_KEY, CAPTURE_TAB_KEY], result => {
     const { state } = (result[CAPTURE_STATE_KEY] ?? {}) as { state?: string };
     tabId = (result[CAPTURE_TAB_KEY] as number | null) ?? null;
@@ -56,10 +55,8 @@ export const initBadgeListener = () => {
       tabId = (changes[CAPTURE_TAB_KEY].newValue as number) ?? null;
     }
 
-    // Clear badge on the previous tab (handles tab change and capture end)
     clearBadgeForTab(prevTabId);
 
-    // Set badge on the current tab if actively capturing
     if (color && tabId) {
       setBadgeForTab(tabId, color);
     }

--- a/chrome-extension/src/services/indexed-db.service.ts
+++ b/chrome-extension/src/services/indexed-db.service.ts
@@ -91,10 +91,9 @@ export const deleteBefore = async (tabId: number, cutoffTimestamp: number): Prom
   const objectStore = transaction.objectStore(EVENTS_STORE_NAME);
   const tabTimestampIndex = objectStore.index(INDEX_BY_TAB_TIMESTAMP);
 
-  // delete keys where tabId == tabId AND timestamp < cutoffTimestamp
   const lower = [tabId, Number.NEGATIVE_INFINITY];
   const upper = [tabId, cutoffTimestamp];
-  const keyRange = IDBKeyRange.bound(lower, upper, false, true); // upperOpen=true excludes cutoff
+  const keyRange = IDBKeyRange.bound(lower, upper, false, true);
 
   await new Promise<void>((resolve, reject) => {
     const cursorRequest = tabTimestampIndex.openCursor(keyRange);

--- a/chrome-extension/src/services/menus.service.ts
+++ b/chrome-extension/src/services/menus.service.ts
@@ -13,7 +13,7 @@ export const removeContextMenus = async (): Promise<void> => {
   try {
     await contextMenus.removeAll();
   } catch {
-    // silent
+    // ignore
   }
 };
 

--- a/chrome-extension/src/services/mic-permission.service.ts
+++ b/chrome-extension/src/services/mic-permission.service.ts
@@ -1,13 +1,6 @@
 import { recordingSettingsStorage } from '@extension/storage';
 import type { MicPermission } from '@extension/storage';
 
-/**
- * Sync the browser's microphone permission state to extension storage.
- * Runs on startup to catch permission changes made between sessions
- * (e.g. user revoked mic access in browser settings).
- *
- * Firefox doesn't support permissions.query for microphone — fails silently.
- */
 export const syncMicPermission = async (): Promise<void> => {
   try {
     const status = await navigator.permissions.query({ name: 'microphone' as PermissionName });

--- a/chrome-extension/src/services/tabs.service.ts
+++ b/chrome-extension/src/services/tabs.service.ts
@@ -63,7 +63,6 @@ export const handleOnTabUpdated = async (tabId: number, changeInfo: Tabs.OnUpdat
         annotationsStorage.clearAll(),
         annotationsRedoStorage.clearAll(),
         annotationsHistoryStorage.clearAll(),
-        // rewindService.deleteTab(tabId),
       ]);
     }
   } catch (err) {

--- a/chrome-extension/src/utils/decode-request-body.util.ts
+++ b/chrome-extension/src/utils/decode-request-body.util.ts
@@ -12,7 +12,7 @@ export const decodeRequestBody = (requestBody?: {
     try {
       parsed = JSON.parse(decoded);
     } catch {
-      // not JSON, keep as plain string
+      // not JSON
     }
 
     return { decoded, parsed };

--- a/chrome-extension/src/utils/persist-tokens.util.ts
+++ b/chrome-extension/src/utils/persist-tokens.util.ts
@@ -1,11 +1,3 @@
-/**
- * Extracts access/refresh tokens from a URL fragment of the form:
- *    https://…/#access_token=XXX&refresh_token=YYY
- * Saves them in storage and returns the persisted object.
- *
- * @param url - The final redirect URL captured by the auth flow.
- * @returns    The stored { accessToken, refreshToken } object.
- */
 import { authTokensStorage } from '@extension/storage';
 import type { ITokens } from '@extension/storage';
 

--- a/chrome-extension/src/utils/plugins/make-manifest-plugin.ts
+++ b/chrome-extension/src/utils/plugins/make-manifest-plugin.ts
@@ -46,7 +46,7 @@ const addRefreshContentScript = (manifest: ManifestType) => {
   manifest.content_scripts = manifest.content_scripts || [];
   manifest.content_scripts.push({
     matches: ['http://*/*', 'https://*/*', '<all_urls>'],
-    js: ['refresh.js'], // for public's HMR(refresh) support
+    js: ['refresh.js'],
   });
 };
 

--- a/chrome-extension/src/utils/rewind.util.ts
+++ b/chrome-extension/src/utils/rewind.util.ts
@@ -1,4 +1,3 @@
-// rewind.service.ts
 import type { Runtime } from 'webextension-polyfill';
 
 import { REWIND, isRewindBlocked, sendMessageToTab } from '@extension/shared';
@@ -8,10 +7,10 @@ import { deleteTabAll, deleteBefore, getRange, putBatch } from '@src/services';
 const WINDOW_DURATION_MS = 60_000;
 const CLEANUP_CUSHION_MS = 10_000;
 
-const FLUSH_INTERVAL_MS = 2_000; // best-effort only (MV3 timers unreliable)
-const FLUSH_THRESHOLD_EVENTS = 1_000; // best-effort only
+// best-effort only (MV3 timers unreliable)
+const FLUSH_INTERVAL_MS = 2_000;
+const FLUSH_THRESHOLD_EVENTS = 1_000;
 
-// rrweb event types
 const RRWEB_FULL_SNAPSHOT_EVENT_TYPE = 2;
 const RRWEB_META_EVENT_TYPE = 4;
 
@@ -57,10 +56,8 @@ type TabRewindState = {
 
   latestEventTimestampSeen: number | null;
 
-  // in-memory anchor cache (diagnostic + fallback)
   anchors: AnchorCache;
 
-  // logging guard
   hasLoggedMissingAnchors: boolean;
 
   frozenSnapshot: FrozenRewindSnapshot | null;
@@ -138,12 +135,7 @@ const getEventTimestamp = (payload: unknown): number => {
   return typeof ts === 'number' && Number.isFinite(ts) ? ts : Date.now();
 };
 
-/**
- * rrweb versions and wrappers can differ. Be defensive:
- * - most: event.type is number
- * - sometimes payload could be wrapped: { event: {...} } (your own structure)
- * - sometimes: event.data?.type (rare but seen in pipelines)
- */
+// rrweb versions/wrappers vary: direct `type`, nested `event.type`, or `data.type`.
 const getEventType = (payload: unknown): number | null => {
   const direct = (payload as any)?.type;
   if (typeof direct === 'number') return direct;
@@ -206,10 +198,7 @@ const pickStrictRetentionCutoff = (tabState: TabRewindState, fallbackNow: number
   return latest - WINDOW_DURATION_MS - CLEANUP_CUSHION_MS;
 };
 
-/**
- * LOSSLESS flush: does not drop pending events if IDB write fails.
- * Coalesces concurrent flush calls via flushInFlightPromise.
- */
+// Lossless: keeps pending events if IDB write fails; coalesces concurrent calls.
 const flushTabToStorage = async (tabId: number): Promise<void> => {
   const tabState = getTabRewindState(tabId);
   if (tabState.flushInFlightPromise) return tabState.flushInFlightPromise;
@@ -221,7 +210,6 @@ const flushTabToStorage = async (tabId: number): Promise<void> => {
 
     const pendingSnapshot = tabState.pendingEvents.slice();
 
-    // update in-memory caches before attempting storage
     updateLatestSeen(tabState, pendingSnapshot);
     updateAnchorCacheFromPending(tabState, pendingSnapshot);
 
@@ -235,16 +223,14 @@ const flushTabToStorage = async (tabId: number): Promise<void> => {
 
       if (tabState.generation !== flushGen) return;
 
-      // commit: drop what we wrote (keep newly queued)
       tabState.pendingEvents.splice(0, pendingSnapshot.length);
 
-      // strict prune: NEVER pin by anchors (that was your >1min bug)
+      // Strict prune: never pin retention by anchors (prevents >1min window growth).
       const cutoff = pickStrictRetentionCutoff(tabState, Date.now());
       await deleteBefore(tabId, cutoff);
     } catch (err) {
       console.error('[brie|rewind] flush failed', err);
 
-      // keep pending; cap memory if IDB is broken
       const MAX_PENDING_EVENTS = 20_000;
       if (tabState.pendingEvents.length > MAX_PENDING_EVENTS) {
         tabState.pendingEvents.splice(0, tabState.pendingEvents.length - MAX_PENDING_EVENTS);
@@ -297,7 +283,7 @@ const ensureAnchorsInReturnedWindow = async (
     if (hasMetaInWindow && hasFullSnapshotInWindow) break;
   }
 
-  // Try storage lookback first (truth source), then in-memory cache.
+  // Prefer storage lookback (truth source) over the in-memory cache fallback.
   let meta: unknown | null = null;
   let full: unknown | null = null;
 
@@ -313,8 +299,8 @@ const ensureAnchorsInReturnedWindow = async (
 
   const missingAnchor = !(hasMetaInWindow || meta) || !(hasFullSnapshotInWindow || full);
 
-  // Inject missing anchors inside the 1-min range (strict requirement).
-  // Put them at the start, in correct order: meta then full snapshot.
+  // Inject anchors at the window start in rrweb order (meta, then full snapshot)
+  // so the player can hydrate from the very first frame of the returned range.
   const injected: unknown[] = [];
 
   if (!hasMetaInWindow && meta) {
@@ -326,7 +312,6 @@ const ensureAnchorsInReturnedWindow = async (
 
   const events = injected.length ? [...injected, ...windowEvents] : windowEvents;
 
-  // One-time debug if anchors are still missing, so you can see whether rrweb is emitting them at all.
   if (missingAnchor && !tabState.hasLoggedMissingAnchors) {
     tabState.hasLoggedMissingAnchors = true;
     console.warn('[brie|rewind] missing anchors on freeze', {
@@ -408,7 +393,7 @@ const resetTabRewind = async (tabId: number): Promise<void> => {
   try {
     await tabState.flushInFlightPromise;
   } catch {
-    // ignore
+    // ignore failures from a flush we are about to discard
   } finally {
     tabState.flushInFlightPromise = null;
   }

--- a/packages/shared/lib/constants/sensitive-keywords.constants.ts
+++ b/packages/shared/lib/constants/sensitive-keywords.constants.ts
@@ -65,7 +65,6 @@ const STRONG_KEYS = [
 // Explicitly DO NOT redact these by name
 const EXEMPT_KEYS = ['username', 'user_name', 'email', 'e-mail', 'login', 'user', 'user_id', 'userid'];
 
-// Non-sensitive/date-ish by default
 const NON_SENSITIVE_KEYS = [
   'date',
   'start_date',

--- a/packages/shared/lib/utils/redact-sensitive-info.util.ts
+++ b/packages/shared/lib/utils/redact-sensitive-info.util.ts
@@ -24,11 +24,6 @@ const classifyField = (ctx: {
   return 'unknown';
 };
 
-/**
- * Applies redaction rules to a raw string using defined regex patterns.
- * @param value - The string to redact.
- * @returns Redacted string.
- */
 const redactString = (value: string, ctxStrength: Strength): string => {
   if (!value || ctxStrength === 'allow') return value;
 
@@ -58,7 +53,6 @@ const redactString = (value: string, ctxStrength: Strength): string => {
   return out;
 };
 
-/** Redact a string that may contain JSON while preserving string type. */
 const redactPossiblyJsonString = (
   input: string,
   shouldSkipRedaction: boolean,
@@ -77,11 +71,6 @@ const redactPossiblyJsonString = (
   return redactString(input, ctx?.strength ?? 'unknown');
 };
 
-/**
- * Determines if an object contains a context where `name` matches a sensitive key.
- * @param obj - The object to inspect.
- * @returns True if the context suggests sensitive data.
- */
 const shouldRedactByNameValueContext = (obj: any): boolean => {
   const name = typeof obj?.name === 'string' ? obj.name : undefined;
   const key = typeof obj?.key === 'string' ? obj.key : undefined;
@@ -89,12 +78,6 @@ const shouldRedactByNameValueContext = (obj: any): boolean => {
   return keyMatches(name, STRONG_KEYS) || keyMatches(key, STRONG_KEYS);
 };
 
-/**
- * Internal recursive function that redacts sensitive values.
- * @param input - Any data.
- * @param shouldSkipRedaction - If true, redaction is bypassed entirely.
- * @param ctx - Optional context (derived from key/name/label/type).
- */
 const deepRedactInternal = (input: any, shouldSkipRedaction: boolean, ctx?: { strength: Strength }): any => {
   if (shouldSkipRedaction || input === null || input === undefined) return input;
 
@@ -110,16 +93,14 @@ const deepRedactInternal = (input: any, shouldSkipRedaction: boolean, ctx?: { st
 
   const result: Record<string, any> = {};
   for (const [key, value] of Object.entries(input)) {
-    // Build field-level context
     const fieldCtx = {
       key,
       name: typeof (input as any).name === 'string' ? (input as any).name : undefined,
       label: typeof (input as any).label === 'string' ? (input as any).label : undefined,
       type: typeof (input as any).type === 'string' ? (input as any).type : undefined,
     };
-    const strength = classifyField(fieldCtx); // 'strong' | 'allow' | 'unknown'
+    const strength = classifyField(fieldCtx);
 
-    // CASE 1: value in { key: "secret", value: "..." }
     if (key === 'value' && typeof value === 'string') {
       const nameKeyStrong =
         shouldRedactByNameValueContext(input) ||
@@ -134,36 +115,25 @@ const deepRedactInternal = (input: any, shouldSkipRedaction: boolean, ctx?: { st
       continue;
     }
 
-    // CASE 2: key-value pairs like { secret: "..." }
     if (typeof key === 'string' && typeof value === 'string') {
       if (keyMatches(key, STRONG_KEYS)) {
         result[key] = REDACTED_KEYWORD;
         continue;
       }
       if (keyMatches(key, EXEMPT_KEYS) || keyMatches(key, NON_SENSITIVE_KEYS)) {
-        // explicitly allowed by name
         result[key] = value;
         continue;
       }
-      // otherwise process string with context
       result[key] = deepRedactInternal(value, shouldSkipRedaction, { strength });
       continue;
     }
 
-    // Recurse for nested structures, propagate context strength for this field
     result[key] = deepRedactInternal(value, shouldSkipRedaction, { strength });
   }
 
   return result;
 };
 
-/**
- * Checks if the given URL matches any domain in the skip list.
- *
- * @param url - The URL to check.
- * @param skipDomains - List of domain patterns to skip redaction for.
- * @returns True if the URL matches a domain in the skip list.
- */
 const isSkipDomain = (url?: string, skipDomains?: string[]): boolean => {
   if (!url || !skipDomains || skipDomains.length === 0) return false;
 
@@ -172,14 +142,8 @@ const isSkipDomain = (url?: string, skipDomains?: string[]): boolean => {
 };
 
 /**
- * Deeply redacts sensitive information from an input structure.
- * Automatically skips redaction in non-production environments or
- * when the URL matches a domain in the user-configured skip list.
- *
- * @param input - Any value (object, array, string, etc.) to redact.
- * @param url - Optional URL to determine if redaction should apply (e.g. non-prod).
- * @param skipDomains - Optional list of domain patterns for which redaction is skipped.
- * @returns Redacted copy of the input.
+ * Deeply redacts sensitive information. Skips redaction in non-production
+ * environments or when the URL matches a domain in `skipDomains`.
  */
 export const deepRedactSensitiveInfo = (input: any, url?: string, skipDomains?: string[]): any => {
   const shouldSkipRedaction = isNonProduction(url) || isSkipDomain(url, skipDomains);

--- a/packages/storage/lib/base/base.ts
+++ b/packages/storage/lib/base/base.ts
@@ -1,29 +1,20 @@
 import { SessionAccessLevelEnum, StorageEnum } from './enums.js';
 import type { BaseStorage, StorageConfig, ValueOrUpdate } from './types.js';
 
-/**
- * Chrome reference error while running `processTailwindFeatures` in tailwindcss.
- *  To avoid this, we need to check if the globalThis.chrome is available and add fallback logic.
- */
+// `globalThis.chrome` is undefined when this module is evaluated by tailwindcss's
+// `processTailwindFeatures` at build time; downstream calls must tolerate that.
 const chrome = globalThis.chrome;
 
-/**
- * Sets or updates an arbitrary cache with a new value or the result of an update function.
- */
 const updateCache = async <D>(valueOrUpdate: ValueOrUpdate<D>, cache: D | null): Promise<D> => {
-  // Type guard to check if our value or update is a function
   const isFunction = <D>(value: ValueOrUpdate<D>): value is (prev: D) => D | Promise<D> => {
     return typeof value === 'function';
   };
 
-  // Type guard to check in case of a function, if its a Promise
   const returnsPromise = <D>(func: (prev: D) => D | Promise<D>): func is (prev: D) => Promise<D> => {
-    // Use ReturnType to infer the return type of the function and check if it's a Promise
     return (func as (prev: D) => Promise<D>) instanceof Promise;
   };
 
   if (isFunction(valueOrUpdate)) {
-    // Check if the function returns a Promise
     if (returnsPromise(valueOrUpdate)) {
       return valueOrUpdate(cache as D);
     } else {
@@ -34,15 +25,9 @@ const updateCache = async <D>(valueOrUpdate: ValueOrUpdate<D>, cache: D | null):
   }
 };
 
-/**
- * If one session storage needs access from content scripts, we need to enable it globally.
- * @default false
- */
+// Session access level can only be set once per extension process.
 let globalSessionAccessLevelFlag: StorageConfig['sessionAccessForContentScripts'] = false;
 
-/**
- * Checks if the storage permission is granted in the manifest.json.
- */
 const checkStoragePermission = (storageEnum: StorageEnum): void => {
   if (!chrome) {
     return;
@@ -53,9 +38,6 @@ const checkStoragePermission = (storageEnum: StorageEnum): void => {
   }
 };
 
-/**
- * Creates a storage area for persisting and exchanging data.
- */
 export const createStorage = <D = string>(key: string, fallback: D, config?: StorageConfig<D>): BaseStorage<D> => {
   let cache: D | null = null;
   let initedCache = false;
@@ -67,7 +49,6 @@ export const createStorage = <D = string>(key: string, fallback: D, config?: Sto
   const serialize = config?.serialization?.serialize ?? ((v: D) => v);
   const deserialize = config?.serialization?.deserialize ?? (v => v as D);
 
-  // Set global session storage access level for StoryType.Session, only when not already done but needed.
   if (
     globalSessionAccessLevelFlag === false &&
     storageEnum === StorageEnum.Session &&
@@ -85,7 +66,6 @@ export const createStorage = <D = string>(key: string, fallback: D, config?: Sto
     globalSessionAccessLevelFlag = true;
   }
 
-  // Register life cycle methods
   const get = async (): Promise<D> => {
     checkStoragePermission(storageEnum);
     const value = await chrome?.storage[storageEnum].get([key]);
@@ -94,9 +74,8 @@ export const createStorage = <D = string>(key: string, fallback: D, config?: Sto
       return fallback;
     }
 
-    // value[key] is typed `unknown` in newer @types/chrome (chrome.storage can
-    // hold any JSON-serializable value); we always write via `serialize` which
-    // returns string, so re-narrowing here matches what we actually wrote.
+    // value[key] is typed `unknown` in newer @types/chrome; we always write via
+    // `serialize` which returns string, so re-narrowing matches what we wrote.
     return deserialize(value[key] as string) ?? fallback;
   };
 
@@ -140,9 +119,7 @@ export const createStorage = <D = string>(key: string, fallback: D, config?: Sto
     _emitChange();
   });
 
-  // Listener for live updates from the browser
   const _updateFromStorageOnChanged = async (changes: { [key: string]: chrome.storage.StorageChange }) => {
-    // Check if the key we are listening for is in the changes object
     if (changes[key] === undefined) return;
 
     const valueOrUpdate: ValueOrUpdate<D> = deserialize(changes[key].newValue as string);
@@ -154,7 +131,6 @@ export const createStorage = <D = string>(key: string, fallback: D, config?: Sto
     _emitChange();
   };
 
-  // Register listener for live updates for our storage area
   if (liveUpdate) {
     chrome?.storage[storageEnum].onChanged.addListener(_updateFromStorageOnChanged);
   }

--- a/packages/storage/lib/factories/annotation-storage.factory.ts
+++ b/packages/storage/lib/factories/annotation-storage.factory.ts
@@ -27,9 +27,6 @@ export type AnnotationsStorage = BaseStorage<AnnotationMap> & {
   clearAll: () => Promise<void>;
 };
 
-/**
- * Factory for annotation map storage with a custom key.
- */
 export const createAnnotationStorage = (storageKey: string): AnnotationsStorage => {
   const storage = createStorage<AnnotationMap>(
     storageKey,

--- a/pages/content-runtime/src/App.tsx
+++ b/pages/content-runtime/src/App.tsx
@@ -1,9 +1,3 @@
-import { useEffect } from 'react';
-
 export default function App() {
-  useEffect(() => {
-    // console.log('runtime content view loaded');
-  }, []);
-
   return <div className="runtime-content-view-text">runtime content view</div>;
 }

--- a/pages/content-runtime/src/Root.tsx
+++ b/pages/content-runtime/src/Root.tsx
@@ -16,7 +16,7 @@ export const mount = () => {
     try {
       activeRoot.unmount();
     } catch {
-      // Root may already be invalid.
+      //
     }
     activeRoot = null;
   }

--- a/pages/content-ui/src/components/annotation-view/canvas-container.view.tsx
+++ b/pages/content-ui/src/components/annotation-view/canvas-container.view.tsx
@@ -55,90 +55,16 @@ const CanvasContainerView = ({ screenshot, onElement, captureState }: CanvasCont
   const [actionMenuVisible, setActionMenuVisible] = useState(false);
   const [menuPosition, setMenuPosition] = useState({ left: 0, top: 0 });
 
-  /**
-   * useStorage is a hook provided by local store that allows you to store
-   * data in a key-value store and automatically sync it with other users
-   * i.e., subscribes to updates to that selected data
-   *
-   * Over here, we are storing the canvas objects in the key-value store.
-   */
-
-  /**
-   * canvasRef is a reference to the canvas element that we'll use to initialize
-   * the fabric canvas.
-   *
-   * fabricRef is a reference to the fabric canvas that we use to perform
-   * operations on the canvas. It's a copy of the created canvas so we can use
-   * it outside the canvas event listeners.
-   */
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const fabricRef = useRef<Canvas | null>(null);
-
-  /**
-   * isDrawing is a boolean that tells us if the user is drawing on the canvas.
-   * We use this to determine if the user is drawing or not
-   * i.e., if the freeform drawing mode is on or not.
-   */
   const isDrawing = useRef(false);
-
-  /**
-   * shapeRef is a reference to the shape that the user is currently drawing.
-   * We use this to update the shape's properties when the user is
-   * drawing/creating shape
-   */
   const shapeRef = useRef<FabricObject | null>(null);
-
-  /**
-   * selectedShapeRef is a reference to the shape that the user has selected.
-   * For example, if the user has selected the rectangle shape, then this will
-   * be set to "rectangle".
-   *
-   * We're using refs here because we want to access these variables inside the
-   * event listeners. We don't want to lose the values of these variables when
-   * the component re-renders. Refs help us with that.
-   */
   const selectedShapeRef = useRef<string | null>(null);
-
-  /**
-   * activeObjectRef is a reference to the active/selected object in the canvas
-   *
-   * We want to keep track of the active object so that we can keep it in
-   * selected form when user is editing the width, height, color etc
-   * properties/attributes of the object.
-   *
-   * Since we're using live storage to sync shapes across users in real-time,
-   * we have to re-render the canvas when the shapes are updated.
-   * Due to this re-render, the selected shape is lost. We want to keep track
-   * of the selected shape so that we can keep it selected when the
-   * canvas re-renders.
-   */
   const activeObjectRef = useRef<FabricObject | null>(null);
   const isEditingRef = useRef(false);
-
-  /**
-   * imageInputRef is a reference to the input element that we use to upload
-   * an image to the canvas.
-   *
-   * We want image upload to happen when clicked on the image item from the
-   * dropdown menu. So we're using this ref to trigger the click event on the
-   * input element when the user clicks on the image item from the dropdown.
-   */
   const imageInputRef = useRef<HTMLInputElement>(null);
 
-  /**
-   * activeElement is an object that contains the name, value and icon of the
-   * active element in the navbar.
-   */
   const [activeElement, setActiveElement] = useState<ActiveElement>(defaultNavElement);
-
-  /**
-   * elementAttributes is an object that contains the attributes of the selected
-   * element in the canvas.
-   *
-   * We use this to update the attributes of the selected element when the user
-   * is editing the width, height, color etc properties/attributes of the
-   * object.
-   */
 
   const [elementAttributes, setElementAttributes] = useState<Attributes>({
     width: '',
@@ -151,10 +77,6 @@ const CanvasContainerView = ({ screenshot, onElement, captureState }: CanvasCont
   });
   const currentColorRef = useRef<string>('#ef4444');
 
-  /**
-   * useUndo and useRedo are hooks provided by local store that allow you to
-   * undo and redo mutations.
-   */
   const restoreObjects = useCallback(
     async (canvas: any, snapshot?: { objects?: any[] }) => {
       const { meta } = (await annotationsStorage.getAnnotations(screenshot.id!)) ?? {};
@@ -207,21 +129,8 @@ const CanvasContainerView = ({ screenshot, onElement, captureState }: CanvasCont
     }
   }, [screenshot?.id, restoreObjects]);
 
-  /**
-   * deleteShapeFromStorage is a mutation that deletes a shape from the
-   * key-value store of local store.
-   * useMutation is a hook provided by local store that allows you to perform
-   * mutations on local store data.
-   *
-   * We're using this mutation to delete a shape from the key-value store when
-   * the user deletes a shape from the canvas.
-   */
   const deleteShapeFromStorage = useCallback(
     async (shapeId: string) => {
-      /**
-       * canvasObjects is a Map that contains all the shapes in the key-value.
-       * Like a store. We can create multiple stores in local store.
-       */
       const { objects } = (await annotationsStorage.getAnnotations(screenshot.id!)) ?? {};
       if (!objects) return;
 
@@ -241,13 +150,6 @@ const CanvasContainerView = ({ screenshot, onElement, captureState }: CanvasCont
     [screenshot?.id],
   );
 
-  /**
-   * deleteAllShapes is a mutation that deletes all the shapes from the
-   * key-value store of local store.
-   *
-   * We're using this mutation to delete all the shapes from the key-value store
-   * when the user clicks on the reset button.
-   */
   const deleteAllShapes = useCallback(async () => {
     if (fabricRef.current) {
       const bg = fabricRef.current.backgroundImage;
@@ -263,14 +165,6 @@ const CanvasContainerView = ({ screenshot, onElement, captureState }: CanvasCont
     ]);
   }, [screenshot?.id]);
 
-  /**
-   * syncShapeInStorage is a mutation that syncs the shape in the key-value
-   * store of local store.
-   *
-   * We're using this mutation to sync the shape in the key-value store
-   * whenever user performs any action on the canvas such as drawing, moving
-   * editing, deleting etc.
-   */
   const syncShapeInStorage = useCallback(
     async (object: any) => {
       if (!object || !fabricRef.current) return;
@@ -304,12 +198,6 @@ const CanvasContainerView = ({ screenshot, onElement, captureState }: CanvasCont
     [screenshot?.id],
   );
 
-  /**
-   * Set the active element in the navbar and perform the action based
-   * on the selected element.
-   *
-   * @param elem
-   */
   const handleActiveElement = useCallback(
     (elem: ActiveElement) => {
       if (elem?.value === 'color-palette') {
@@ -349,37 +237,22 @@ const CanvasContainerView = ({ screenshot, onElement, captureState }: CanvasCont
           redo();
           break;
 
-        // delete all the shapes from the canvas
         case 'start_over':
-          // clear the storage
           deleteAllShapes();
-          // clear the canvas
           fabricRef.current?.clear();
-          // set "select" as the active element
           setActiveElement(defaultNavElement);
           break;
 
-        // delete the selected shape from the canvas
         case 'delete':
-          // delete it from the canvas
           handleDelete(fabricRef.current as any, deleteShapeFromStorage);
-          // set "select" as the active element
           setActiveElement(defaultNavElement);
           break;
 
-        // upload an image to the canvas
         case 'image':
-          // trigger the click event on the input element which opens the file dialog
           imageInputRef.current?.click();
-          /**
-           * set drawing mode to false
-           * If the user is drawing on the canvas, we want to stop the
-           * drawing mode when clicked on the image item from the dropdown.
-           */
           isDrawing.current = false;
 
           if (fabricRef.current) {
-            // disable the drawing mode of canvas
             fabricRef.current.isDrawingMode = false;
           }
           break;
@@ -453,13 +326,6 @@ const CanvasContainerView = ({ screenshot, onElement, captureState }: CanvasCont
 
     getSavedAnnotations();
 
-    /**
-     * listen to the mouse down event on the canvas which is fired when the
-     * user clicks on the canvas
-     *
-     * Event inspector: http://fabricjs.com/events
-     * Event list: http://fabricjs.com/docs/fabric.Canvas.html#fire
-     */
     canvas.on('mouse:down', options => {
       handleCanvasMouseDown({
         options,
@@ -475,13 +341,6 @@ const CanvasContainerView = ({ screenshot, onElement, captureState }: CanvasCont
       }
     });
 
-    /**
-     * listen to the mouse move event on the canvas which is fired when the
-     * user moves the mouse on the canvas
-     *
-     * Event inspector: http://fabricjs.com/events
-     * Event list: http://fabricjs.com/docs/fabric.Canvas.html#fire
-     */
     canvas.on('mouse:move', options => {
       handleCanvasMouseMove({
         options,
@@ -493,13 +352,6 @@ const CanvasContainerView = ({ screenshot, onElement, captureState }: CanvasCont
       });
     });
 
-    /**
-     * listen to the mouse up event on the canvas which is fired when the
-     * user releases the mouse on the canvas
-     *
-     * Event inspector: http://fabricjs.com/events
-     * Event list: http://fabricjs.com/docs/fabric.Canvas.html#fire
-     */
     canvas.on('mouse:up', () => {
       handleCanvasMouseUp({
         canvas,
@@ -512,14 +364,6 @@ const CanvasContainerView = ({ screenshot, onElement, captureState }: CanvasCont
       });
     });
 
-    /**
-     * listen to the path created event on the canvas which is fired when
-     * the user creates a path on the canvas using the freeform drawing
-     * mode
-     *
-     * Event inspector: http://fabricjs.com/events
-     * Event list: http://fabricjs.com/docs/fabric.Canvas.html#fire
-     */
     canvas.on('path:created', options => {
       handlePathCreated({
         options,
@@ -527,15 +371,6 @@ const CanvasContainerView = ({ screenshot, onElement, captureState }: CanvasCont
       });
     });
 
-    /**
-     * listen to the object modified event on the canvas which is fired
-     * when the user modifies an object on the canvas. Basically, when the
-     * user changes the width, height, color etc properties/attributes of
-     * the object or moves the object on the canvas.
-     *
-     * Event inspector: http://fabricjs.com/events
-     * Event list: http://fabricjs.com/docs/fabric.Canvas.html#fire
-     */
     canvas.on('object:modified', options => {
       handleCanvasObjectModified({
         options,
@@ -543,13 +378,6 @@ const CanvasContainerView = ({ screenshot, onElement, captureState }: CanvasCont
       });
     });
 
-    /**
-     * listen to the object moving event on the canvas which is fired
-     * when the user moves an object on the canvas.
-     *
-     * Event inspector: http://fabricjs.com/events
-     * Event list: http://fabricjs.com/docs/fabric.Canvas.html#fire
-     */
     canvas?.on('object:moving', options => {
       handleCanvasObjectMoving({
         options,
@@ -558,13 +386,6 @@ const CanvasContainerView = ({ screenshot, onElement, captureState }: CanvasCont
       updateMenuPosition(options);
     });
 
-    /**
-     * listen to the selection created event on the canvas which is fired
-     * when the user selects an object on the canvas.
-     *
-     * Event inspector: http://fabricjs.com/events
-     * Event list: http://fabricjs.com/docs/fabric.Canvas.html#fire
-     */
     canvas.on('selection:created', options => {
       handleCanvasSelectionCreated({
         options,
@@ -586,13 +407,7 @@ const CanvasContainerView = ({ screenshot, onElement, captureState }: CanvasCont
     canvas.on('selection:cleared', options => {
       setActionMenuVisible(false);
     });
-    /**
-     * listen to the scaling event on the canvas which is fired when the
-     * user scales an object on the canvas.
-     *
-     * Event inspector: http://fabricjs.com/events
-     * Event list: http://fabricjs.com/docs/fabric.Canvas.html#fire
-     */
+
     canvas.on('object:scaling', options => {
       handleCanvasObjectScaling({
         options,
@@ -606,19 +421,7 @@ const CanvasContainerView = ({ screenshot, onElement, captureState }: CanvasCont
       updateMenuPosition(options);
     });
 
-    /**
-     * listen to the mouse wheel event on the canvas which is fired when
-     * the user scrolls the mouse wheel on the canvas.
-     *
-     * Event inspector: http://fabricjs.com/events
-     * Event list: http://fabricjs.com/docs/fabric.Canvas.html#fire
-     */
-    canvas.on('mouse:wheel', () => {
-      // handleCanvasZoom({
-      //   options,
-      //   canvas,
-      // });
-    });
+    canvas.on('mouse:wheel', () => {});
 
     const onWindowResize = () => {
       handleResize({
@@ -653,11 +456,10 @@ const CanvasContainerView = ({ screenshot, onElement, captureState }: CanvasCont
         shadow.removeEventListener('keydown', onShadowKeyDown);
       }
     };
-  }, [screenshot?.id]); // run this effect only once when the component mounts and the canvasRef changes
+  }, [screenshot?.id]);
 
   useFitCanvasToParent(fabricRef.current, screenshot, gridCellRef.current);
 
-  // Warn the user when they try to close or refresh the tab
   useEffect(() => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
       if (captureState !== 'unsaved') return;

--- a/pages/content-ui/src/components/annotation-view/ui/header.ui.tsx
+++ b/pages/content-ui/src/components/annotation-view/ui/header.ui.tsx
@@ -7,29 +7,23 @@ import { CreateDropdown, EditableTitle, WorkspacesDropdown } from '@src/componen
 import { useAnnotationActionAvailability } from '@src/providers';
 
 interface EditorHeaderProps {
-  /** active screenshot id */
   id: string;
 
-  /** window controls */
   onClose: () => void;
   onMinimize?: () => void;
   onToggleFullScreen: () => void;
   isFullScreen?: boolean;
 
-  /** title */
   title: string;
   onTitleChange: (val: string) => void;
 
-  /** undo / redo / start over */
   onUndo: () => void;
   onRedo: () => void;
   onStartOver: () => void;
 
-  /** canvas size read-out */
   canvasWidth: number;
   canvasHeight: number;
 
-  /** workspace & create dropdowns */
   onWorkspaceChange: (id: string) => void;
   createActions: CreateAction[];
   activeCreateAction: CreateAction;

--- a/pages/content-ui/src/components/annotation-view/ui/right-sidebar.ui.tsx
+++ b/pages/content-ui/src/components/annotation-view/ui/right-sidebar.ui.tsx
@@ -172,7 +172,7 @@ export const RightSidebar: React.FC<RightSidebarProps> = ({
       let msg = serverMsg ?? (err?.message === 'EMPTY_STEPS' ? t('noStepsFound') : undefined) ?? t('unexpectedError');
 
       if (code === 'OUTPUT_TRUNCATED') {
-        msg = t('outputTruncated'); // "The generated text was cut off. Try with fewer steps."
+        msg = t('outputTruncated');
       } else if (code === 'NO_CAPTURE_DATA') {
         msg = t('noCaptureData');
       }
@@ -462,8 +462,6 @@ export const RightSidebar: React.FC<RightSidebarProps> = ({
                   )}
                 />
               </div>
-
-              {/* <GenerateDropdown isLoading={isLoading} onGenerate={handleOnGenerate} /> */}
             </div>
           </form>
         </Form>

--- a/pages/content-ui/src/components/annotation-view/ui/toolbar.ui.tsx
+++ b/pages/content-ui/src/components/annotation-view/ui/toolbar.ui.tsx
@@ -58,7 +58,6 @@ const Toolbar = ({ activeElement, onActiveElement, onExport }: ToolbarProps) => 
                         : '',
                     )}
                     variant="ghost"
-                    //   loading={isUpdating}
                     onClick={() => handleOnActiveElement(item)}>
                     <Tooltip>
                       <TooltipTrigger asChild>

--- a/pages/content-ui/src/components/dialog-view/add-to-space.ui.tsx
+++ b/pages/content-ui/src/components/dialog-view/add-to-space.ui.tsx
@@ -89,7 +89,6 @@ export const AddToSpace = ({ workspaceId, onChange }: { workspaceId: string; onC
           </div>
 
           <span>{t('createSpace')}</span>
-          {/* <DropdownMenuShortcut>⇧⌘W</DropdownMenuShortcut> */}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/pages/content-ui/src/components/recording-view/ui/toolbar.ui.tsx
+++ b/pages/content-ui/src/components/recording-view/ui/toolbar.ui.tsx
@@ -38,7 +38,6 @@ export const RecordingToolbar: FC<RecordingToolbarProps> = ({ state, tool, onToo
 
   const handleOnToggleMic = useCallback(async () => {
     safePostMessage(RECORDING.TOGGLE_MIC);
-    // toggleMic in video.capture.ts handles the actual track and updates storage
   }, []);
 
   if (!isVisible) return null;

--- a/pages/content-ui/src/constants/annotation-elements.ts
+++ b/pages/content-ui/src/constants/annotation-elements.ts
@@ -31,7 +31,6 @@ export const shapeElements: ShapeElement[] = [
 ];
 
 export const defaultNavElement: ShapeElement = {
-  // icon: 'MousePointer2Icon',
   icon: 'HandIcon',
   name: 'Move',
   value: 'select',
@@ -179,7 +178,6 @@ export const shortcuts = [
   {
     value: 'export',
     name: 'Export',
-    // shortcut: '⌘ + E',
   },
   {
     value: 'undo',
@@ -194,6 +192,5 @@ export const shortcuts = [
   {
     value: 'start_over',
     name: 'Start Over',
-    // shortcut: '⌘ + D',
   },
 ];

--- a/pages/content-ui/src/content.tsx
+++ b/pages/content-ui/src/content.tsx
@@ -200,7 +200,7 @@ const Content = ({
       try {
         await deleteRecords();
       } catch {
-        //
+        /* noop */
       }
       onClose?.();
       setProgress(0);
@@ -274,7 +274,6 @@ const Content = ({
       });
 
       if (slice?.externalId || slice?.id) {
-        // Narrow slice.id for the tracker branches (the outer guard accepts externalId-only too)
         if (!slice.id) {
           toast(t('openReport'));
           if (slice.externalId) safeOpenNewTab(`${APP_BASE_URL}/s/${slice.externalId}`);
@@ -334,7 +333,6 @@ const Content = ({
         return;
       }
 
-      // Server returned a draft with an error code (eg: GUEST_DAILY_LIMIT)
       toast.error((slice?.message && t(slice.message as Parameters<typeof t>[0])) || t('failedToCreateSlice'));
 
       if (slice?.id) {
@@ -503,12 +501,7 @@ const Content = ({
             duration={trimDuration}
             trim={trim}
             onZoomChange={zoom => {
-              /**
-               * @todo
-               * implement zoon feature: min: 100% and max: 100%
-               */
               console.log('zoom', zoom);
-              // setZoom()
             }}
           />
         </AnnotationsProvider>

--- a/pages/content-ui/src/index.tsx
+++ b/pages/content-ui/src/index.tsx
@@ -29,13 +29,11 @@ if (navigator.userAgent.includes('Firefox')) {
   styleElement.textContent = tailwindcssOutput;
   shadowRoot.appendChild(styleElement);
 } else {
-  /** Inject styles into shadow dom */
   const globalStyleSheet = new CSSStyleSheet();
   globalStyleSheet.replaceSync(tailwindcssOutput);
   shadowRoot.adoptedStyleSheets = [globalStyleSheet];
 }
 
-// Apply the system theme via the storage API
 themeStorage.applySystemTheme();
 const unsubscribeFromThemeChanges = themeStorage.listenToSystemThemeChanges();
 

--- a/pages/content-ui/src/utils/annotation/canvas.util.ts
+++ b/pages/content-ui/src/utils/annotation/canvas.util.ts
@@ -41,7 +41,6 @@ export const getCanvasElement = () => {
   return null;
 };
 
-// initialize fabric canvas
 export const initializeFabric = ({
   fabricRef,
   canvasRef,
@@ -63,13 +62,11 @@ export const initializeFabric = ({
 
   if (backgroundImage) {
     try {
-      // Set the background image and adjust canvas dimensions
       setCanvasBackground({ file: backgroundImage, canvas, parentHeight: height, parentWidth: width });
     } catch (error) {
       console.error('Failed to set the background image:', error);
     }
   }
-  //fabricjs.com/docs/configuring-defaults/
 
   FabricObject.ownDefaults = {
     ...FabricObject.ownDefaults,
@@ -80,13 +77,10 @@ export const initializeFabric = ({
     cornerStyle: 'circle',
   };
 
-  // @todo: https://medium.com/@luizzappa/custom-icon-and-cursor-in-fabric-js-controls-4714ba0ac28f
-
   FabricObject.createControls = () => ({
     controls: createDefaultControls(),
   });
 
-  // set canvas reference to fabricRef so we can use it later anywhere outside canvas listener
   fabricRef.current = canvas;
 
   return canvas;
@@ -106,7 +100,6 @@ export const applyBrush = (tool: 'freeform' | 'highlighter', canvas: Canvas, cur
   canvas.freeDrawingBrush = brush;
 };
 
-// instantiate creation of custom fabric object/shape and add it to canvas
 export const handleCanvasMouseDown = ({
   options,
   canvas,
@@ -115,21 +108,10 @@ export const handleCanvasMouseDown = ({
   shapeRef,
   currentColorRef,
 }: CanvasMouseDown) => {
-  // get pointer coordinates
   const pointer = canvas.getScenePoint(options.e);
-
-  /**
-   * get target object i.e., the object that is clicked
-   * findtarget() returns the object that is clicked
-   *
-   * findTarget: http://fabricjs.com/docs/fabric.Canvas.html#findTarget
-   */
   const target = canvas.findTarget(options.e);
 
-  // set canvas drawing mode to false
   canvas.isDrawingMode = false;
-
-  // if selected shape is freeform, set drawing mode to true and return
 
   if (DRAWING_TOOLS.includes(selectedShapeRef.current!)) {
     applyBrush(selectedShapeRef.current, canvas, currentColorRef);
@@ -141,33 +123,22 @@ export const handleCanvasMouseDown = ({
 
   canvas.isDrawingMode = false;
 
-  // if target is the selected shape or active selection, set isDrawing to false
   if (target && (target.type === selectedShapeRef.current || target.type === 'activeSelection')) {
     isDrawing.current = false;
 
-    // set active object to target
     canvas.setActiveObject(target);
-
-    /**
-     * setCoords() is used to update the controls of the object
-     * setCoords: http://fabricjs.com/docs/fabric.Object.html#setCoords
-     */
     target.setCoords();
   } else {
     isDrawing.current = true;
 
-    // create custom fabric object/shape and set it to shapeRef
     shapeRef.current = createSpecificShape(selectedShapeRef.current, pointer as any, currentColorRef?.current, canvas);
 
-    // if shapeRef is not null, add it to canvas
     if (shapeRef.current) {
-      // add: http://fabricjs.com/docs/fabric.Canvas.html#add
       canvas.add(shapeRef.current);
     }
   }
 };
 
-// handle mouse move event on canvas to draw shapes with different dimensions
 export const handleCanvasMouseMove = ({
   options,
   canvas,
@@ -176,7 +147,6 @@ export const handleCanvasMouseMove = ({
   shapeRef,
   syncShapeInStorage,
 }: CanvasMouseMove) => {
-  // if selected shape is freeform, return
   if (!isDrawing.current) {
     return;
   }
@@ -186,11 +156,8 @@ export const handleCanvasMouseMove = ({
 
   canvas.isDrawingMode = false;
 
-  // get pointer coordinates
   const pointer = canvas.getScenePoint(options.e);
 
-  // depending on the selected shape, set the dimensions of the shape stored in shapeRef in previous step of handelCanvasMouseDown
-  // calculate shape dimensions based on pointer coordinates
   switch (selectedShapeRef?.current) {
     case 'rectangle':
     case 'triangle':
@@ -222,13 +189,11 @@ export const handleCanvasMouseMove = ({
   // requestRenderAll coalesces rapid mouse:move events into one rAF tick (renderAll paints sync each call).
   canvas.requestRenderAll();
 
-  // sync shape in storage
   if (shapeRef.current?.objectId) {
     syncShapeInStorage(shapeRef.current);
   }
 };
 
-// handle mouse up event on canvas to stop drawing shapes
 export const handleCanvasMouseUp = ({
   canvas,
   isDrawing,
@@ -243,15 +208,12 @@ export const handleCanvasMouseUp = ({
     return;
   }
 
-  // sync shape in storage as drawing is stopped
   syncShapeInStorage(shapeRef.current);
 
-  // set everything to null
   shapeRef.current = null;
   activeObjectRef.current = null;
   selectedShapeRef.current = null;
 
-  // if canvas is not in drawing mode, set active element to default nav element after 700ms
   if (!canvas.isDrawingMode) {
     setTimeout(() => {
       setActiveElement(defaultNavElement);
@@ -259,7 +221,6 @@ export const handleCanvasMouseUp = ({
   }
 };
 
-// update shape in storage when object is modified
 export const handleCanvasObjectModified = ({ options, syncShapeInStorage }: CanvasObjectModified) => {
   const target = options.target;
   if (!target) {
@@ -267,13 +228,12 @@ export const handleCanvasObjectModified = ({ options, syncShapeInStorage }: Canv
   }
 
   if (target?.type === 'activeSelection') {
-    // fix this
+    /* noop */
   } else {
     syncShapeInStorage(target);
   }
 };
 
-// update shape in storage when path is created when in freeform mode
 export const handlePathCreated = ({ options, syncShapeInStorage }: CanvasPathCreated) => {
   const path = options.path;
   if (!path) {
@@ -289,7 +249,6 @@ export const handlePathCreated = ({ options, syncShapeInStorage }: CanvasPathCre
   syncShapeInStorage(path);
 };
 
-// check how object is moving on canvas and restrict it to canvas boundaries
 /** Keep object fully inside the canvas, whatever the zoom. */
 export const handleCanvasObjectMoving = ({ options }: { options: any }) => {
   const target = options.target as FabricObject;
@@ -313,28 +272,22 @@ export const handleCanvasObjectMoving = ({ options }: { options: any }) => {
   target.setCoords();
 };
 
-// set element attributes when element is selected
 export const handleCanvasSelectionCreated = ({
   options,
   isEditingRef,
   setElementAttributes,
 }: CanvasSelectionCreated) => {
-  // if user is editing manually, return
   if (isEditingRef.current) {
     return;
   }
 
-  // if no element is selected, return
   if (!options?.selected) {
     return;
   }
 
-  // get the selected element
   const selectedElement: any = options?.selected[0] as FabricObject;
 
-  // if only one element is selected, set element attributes
   if (selectedElement && options.selected.length === 1) {
-    // calculate scaled dimensions of the object
     const scaledWidth = selectedElement?.scaleX
       ? selectedElement?.width * selectedElement?.scaleX
       : selectedElement?.width;
@@ -355,11 +308,9 @@ export const handleCanvasSelectionCreated = ({
   }
 };
 
-// update element attributes when element is scaled
 export const handleCanvasObjectScaling = ({ options, setElementAttributes }: CanvasObjectScaling) => {
   const selectedElement: any = options.target;
 
-  // calculate scaled dimensions of the object
   const scaledWidth = selectedElement?.scaleX
     ? selectedElement?.width * selectedElement?.scaleX
     : selectedElement?.width;
@@ -395,21 +346,16 @@ export const handleResize = ({
   });
 };
 
-// zoom canvas on mouse scroll
 export const handleCanvasZoom = ({ options, canvas }: { options: any; canvas: Canvas }) => {
   const delta = options.e?.deltaY;
   let zoom = canvas.getZoom();
 
-  // allow zooming to min 20% and max 100%
   const minZoom = 0.2;
   const maxZoom = 1;
   const zoomStep = 0.001;
 
-  // calculate zoom based on mouse scroll wheel with min and max zoom
   zoom = Math.min(Math.max(minZoom, zoom + delta * zoomStep), maxZoom);
 
-  // set zoom to canvas
-  // zoomToPoint: http://fabricjs.com/docs/fabric.Canvas.html#zoomToPoint
   canvas.zoomToPoint(new Point(options.e.offsetX, options.e.offsetY), zoom);
 
   options.e.preventDefault();

--- a/pages/content-ui/src/utils/annotation/controls.util.ts
+++ b/pages/content-ui/src/utils/annotation/controls.util.ts
@@ -2,7 +2,6 @@ import { Control, controlsUtils as FabricControls } from 'fabric';
 
 const rotateSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" strokeLinejoin="round" class="lucide lucide-refresh-cw"><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M8 16H3v5"/></svg>`;
 
-// Factory to create all controls with custom renderers
 export const createDefaultControls = () => {
   const {
     scaleSkewCursorStyleHandler,

--- a/pages/content-ui/src/utils/annotation/key-events.util.ts
+++ b/pages/content-ui/src/utils/annotation/key-events.util.ts
@@ -4,24 +4,16 @@ import { v4 as uuidv4 } from 'uuid';
 
 import type { CustomFabricObject, HandleKeyDownDeps } from '@src/models';
 
-/**
- * Is the event target a native form field or contentEditable node?
- */
 const isDomEditor = (el: EventTarget | null): el is HTMLElement =>
   !!el && (/^(INPUT|TEXTAREA|SELECT)$/i.test((el as HTMLElement).tagName) || (el as HTMLElement).isContentEditable);
 
-/**
- * Returns `true` when a Fabric text object is currently being edited.
- */
 const isFabricEditing = (canvas: Canvas): boolean =>
   !!(canvas.getActiveObject() as { isEditing?: boolean } | null)?.isEditing;
 
 export const handleCopy = (canvas: Canvas) => {
   const activeObjects = canvas.getActiveObjects();
   if (activeObjects.length > 0) {
-    // Serialize the selected objects
     const serializedObjects = activeObjects.map(obj => obj.toObject());
-    // Store the serialized objects in the clipboard
     localStorage.setItem('clipboard', JSON.stringify(serializedObjects));
   }
 
@@ -34,17 +26,14 @@ export const handlePaste = (canvas: Canvas, syncShapeInStorage: (shape: FabricOb
     return;
   }
 
-  // Retrieve serialized objects from the clipboard
   const clipboardData = localStorage.getItem('clipboard');
 
   if (clipboardData) {
     try {
       const parsedObjects = JSON.parse(clipboardData);
       parsedObjects.forEach((objData: FabricObject) => {
-        // convert the plain javascript objects retrieved from localStorage into fabricjs objects (deserialization)
         util.enlivenObjects<FabricObject>([objData]).then((enlivenedObjects: FabricObject[]) => {
           enlivenedObjects.forEach(enlivenedObj => {
-            // Offset the pasted objects to avoid overlap with existing objects
             enlivenedObj.set({
               left: enlivenedObj.left || 0 + 20,
               top: enlivenedObj.top || 0 + 20,
@@ -108,7 +97,6 @@ export const handleKeyDown = ({
   syncShapeInStorage,
   deleteShapeFromStorage,
 }: HandleKeyDownDeps) => {
-  // Ignore when typing inside editable elements
   if (isDomEditor(e.target) || isFabricEditing(canvas)) return;
 
   const mod = e.metaKey || e.ctrlKey;

--- a/pages/content-ui/src/utils/slice/report-to-text.util.ts
+++ b/pages/content-ui/src/utils/slice/report-to-text.util.ts
@@ -1,8 +1,5 @@
 export const reportToText = (report: any): string => {
   const lines: string[] = [];
-  //   lines.push(`${report.title} [${report.severity}]`);
-  //   lines.push(report.summary);
-  //   lines.push('');
 
   if (report.steps?.length) {
     lines.push('Steps to Reproduce:');

--- a/pages/content/src/capture/rewind.capture.ts
+++ b/pages/content/src/capture/rewind.capture.ts
@@ -56,8 +56,7 @@ const flushPendingEvents = (): void => {
       t0: Date.now(),
     });
   } catch {
-    // If sending fails, we already popped the batch.
-    // If you want *zero loss*, keep a retry buffer here.
+    //
   } finally {
     clearFlushTimer();
   }
@@ -69,7 +68,6 @@ const scheduleFlush = (): void => {
 };
 
 const stopCaptureInternal = (): void => {
-  // CRITICAL: flush what we have before clearing
   flushPendingEvents();
 
   if (!rrwebStopFunction) {
@@ -82,7 +80,7 @@ const stopCaptureInternal = (): void => {
     rrwebStopFunction();
   } finally {
     rrwebStopFunction = null;
-    flushPendingEvents(); // flush anything enqueued during stop
+    flushPendingEvents();
     pendingEvents.length = 0;
     clearFlushTimer();
   }
@@ -135,7 +133,7 @@ const enqueueEvent = (eventPayload: unknown): void => {
 
   const rrwebType = getEventType(eventPayload);
 
-  // CRITICAL: never delay META or FULL SNAPSHOT. Flush immediately.
+  // rrweb META and FULL_SNAPSHOT must never be delayed — without them, the replay can't bootstrap.
   if (rrwebType === RRWEB_META_EVENT_TYPE || rrwebType === RRWEB_FULL_SNAPSHOT_EVENT_TYPE) {
     flushPendingEvents();
     return;
@@ -198,7 +196,6 @@ export const applyEnabledState = async (enabled: boolean): Promise<void> => {
 };
 
 export const restartRewindCapture = async (): Promise<{ ok: boolean; reason?: string }> => {
-  // Force a new session boundary
   stopCaptureInternal();
 
   const url = window.location.href;

--- a/pages/content/src/capture/screenshot.capture.ts
+++ b/pages/content/src/capture/screenshot.capture.ts
@@ -9,7 +9,6 @@ let lastPointerX = 0;
 let lastPointerY = 0;
 let startX: number, startY: number;
 let isSelecting = false;
-// let cancelled = false;
 let selectionBox: HTMLDivElement;
 let overlay: HTMLDivElement;
 let dimensionLabel: HTMLDivElement;
@@ -23,7 +22,6 @@ const waitForRepaint = () =>
   new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
 const getShadowHost = () => document.getElementById('brie-root');
 
-// Helper Functions
 const addBoundaryBox = (
   canvas: HTMLCanvasElement,
   x: number,
@@ -35,7 +33,6 @@ const addBoundaryBox = (
   const ctx = canvas.getContext('2d');
   if (!ctx) return;
 
-  // Adjust coordinates and dimensions by the scale factors
   const scaledX = x * scaleFactor;
   const scaledY = y * scaleFactor;
   const scaledWidth = width * scaleFactor;
@@ -46,7 +43,6 @@ const addBoundaryBox = (
   ctx.strokeRect(scaledX, scaledY, scaledWidth, scaledHeight);
 };
 
-// Function to crop the selected area
 const cropSelectedArea = (
   canvas: HTMLCanvasElement,
   x: number,
@@ -56,8 +52,8 @@ const cropSelectedArea = (
   scaleFactor: number,
 ): HTMLCanvasElement => {
   const croppedCanvas = document.createElement('canvas');
-  croppedCanvas.width = width * scaleFactor; // Scale the width for higher resolution
-  croppedCanvas.height = height * scaleFactor; // Scale the height for higher resolution
+  croppedCanvas.width = width * scaleFactor;
+  croppedCanvas.height = height * scaleFactor;
 
   const ctx = croppedCanvas.getContext('2d', { willReadFrequently: true });
   if (!ctx) {
@@ -79,23 +75,16 @@ const cropSelectedArea = (
   return croppedCanvas;
 };
 
-// Function to remove the "Preparing Screenshot..." label from the screenshot
 const cleanCanvas = (canvas: HTMLCanvasElement, element: HTMLElement) => {
   const rect = element.getBoundingClientRect();
   const ctx = canvas.getContext('2d');
   if (!ctx) return;
 
-  // Save the current canvas state before clearing
   ctx.save();
-
-  // Clear the area where the message element is
   ctx.clearRect(rect.left, rect.top, rect.width, rect.height);
-
-  // Restore the previous canvas state to avoid affecting other parts
   ctx.restore();
 };
 
-// Create an overlay for selection
 const createOverlay = () => {
   overlay = document.createElement('div');
   Object.assign(overlay.style, {
@@ -116,7 +105,6 @@ const createOverlay = () => {
   document.body.appendChild(overlay);
 };
 
-// Create the selection box
 const createSelectionBox = () => {
   selectionBox = document.createElement('div');
   Object.assign(selectionBox.style, {
@@ -130,7 +118,6 @@ const createSelectionBox = () => {
   document.body.appendChild(selectionBox);
 };
 
-// Create the dimension label
 const createDimensionLabel = () => {
   dimensionLabel = document.createElement('div');
   Object.assign(dimensionLabel.style, {
@@ -148,7 +135,6 @@ const createDimensionLabel = () => {
   document.body.appendChild(dimensionLabel);
 };
 
-// Display a loading message
 const showLoadingMessage = () => {
   loadingMessage = document.createElement('div');
   Object.assign(loadingMessage.style, {
@@ -170,7 +156,6 @@ const showLoadingMessage = () => {
   document.documentElement.appendChild(loadingMessage);
 };
 
-// Hide the loading message
 const hideLoadingMessage = () => {
   loadingMessage?.remove();
   loadingMessage = null;
@@ -182,7 +167,6 @@ const onScroll = () => {
   }
 };
 
-// Position the instructions message dynamically
 const positionInstructionsMessage = (clientX: number, clientY: number) => {
   if (!message) return;
 
@@ -199,8 +183,6 @@ const positionInstructionsMessage = (clientX: number, clientY: number) => {
   message.style.top = `${clientY + offset + scrollY}px`;
 };
 
-// Event Handlers
-// Update the selection box dimensions
 const updateSelectionBox = (e: MouseEvent | TouchEvent) => {
   if (!isSelecting) return;
 
@@ -228,9 +210,8 @@ const updateSelectionBox = (e: MouseEvent | TouchEvent) => {
   dimensionLabel.textContent = `W: ${width.toFixed(0)}px, H: ${height.toFixed(0)}px`;
 };
 
-// Start the selection process
 const onMouseDown = (e: MouseEvent | TouchEvent, mode: 'single' | 'multiple') => {
-  if ('button' in e && e.button !== 0) return; // Only respond to left-click
+  if ('button' in e && e.button !== 0) return;
 
   if (selectionMouseUpHandler) {
     document.removeEventListener('mouseup', selectionMouseUpHandler);
@@ -243,7 +224,6 @@ const onMouseDown = (e: MouseEvent | TouchEvent, mode: 'single' | 'multiple') =>
 
   isSelecting = true;
 
-  // Use viewport-relative coordinates
   const clientX = 'touches' in e ? e.touches[0].clientX : (e as MouseEvent).clientX;
   const clientY = 'touches' in e ? e.touches[0].clientY : (e as MouseEvent).clientY;
 
@@ -268,18 +248,15 @@ const onMouseDown = (e: MouseEvent | TouchEvent, mode: 'single' | 'multiple') =>
   message = null;
 };
 
-// Handle keydown events for ESC press
 const onKeyDown = (e: KeyboardEvent) => {
   if (e.key === 'Escape') {
     cleanup();
     showPreview();
 
-    // Notify Background on ESC
     chrome.runtime.sendMessage({ type: CAPTURE.EXIT });
   }
 };
 
-// Start the selection process for touch
 const onTouchStart = (e: TouchEvent) => {
   isSelecting = true;
   startX = e.touches[0].pageX;
@@ -289,7 +266,6 @@ const onTouchStart = (e: TouchEvent) => {
   e.preventDefault();
 };
 
-// Finish the selection and capture the screenshot
 const onMouseUp = async (e: MouseEvent | TouchEvent, mode: 'single' | 'multiple') => {
   if (!isSelecting) return;
 
@@ -306,13 +282,6 @@ const onMouseUp = async (e: MouseEvent | TouchEvent, mode: 'single' | 'multiple'
 
   cleanup();
 
-  /**
-   * @todo
-   * Improve show loading message logic.
-   * Note: The message should not be visible on screenshots. Only for user.
-   */
-  // showLoadingMessage();
-
   await waitForRepaint();
 
   const isSmall = width < 1 && height < 1;
@@ -321,10 +290,8 @@ const onMouseUp = async (e: MouseEvent | TouchEvent, mode: 'single' | 'multiple'
     : { x: minX, y: minY, width, height };
 
   await captureScreenshots({ ...area, mode });
-  // hideLoadingMessage();
 };
 
-// Move the instructions message with the cursor
 const onMouseMove = (e: MouseEvent) => {
   const { clientX, clientY } = e;
 
@@ -333,7 +300,6 @@ const onMouseMove = (e: MouseEvent) => {
   positionInstructionsMessage(lastPointerX, lastPointerY);
 };
 
-// Finish the selection for touch and capture the screenshot
 const onTouchEnd = async (e: TouchEvent, mode: 'single' | 'multiple') => {
   if (!isSelecting) return;
 
@@ -377,9 +343,8 @@ const showPreview = () => {
   if (shadowHost) shadowHost.hidden = false;
 };
 
-// Show instructions message
 const showInstructions = () => {
-  if (message) return; // Prevent duplicate creation of the message
+  if (message) return;
 
   message = document.createElement('div');
   Object.assign(message.style, {
@@ -395,7 +360,6 @@ const showInstructions = () => {
   message.textContent = t('selectArea');
   document.body.appendChild(message);
 
-  // Move instructions message on mouse/touch move
   document.addEventListener('keydown', onKeyDown);
   document.addEventListener('mousemove', onMouseMove);
   document.addEventListener('touchmove', onTouchMove);
@@ -424,7 +388,6 @@ const checkIfNativeCaptureAvailable = () =>
     });
   });
 
-// Screenshot Capturing
 const captureScreenshots = async ({
   x,
   y,
@@ -441,27 +404,18 @@ const captureScreenshots = async ({
   try {
     const scaleFactor = window.devicePixelRatio || 2;
 
-    // Check if Native Capture API is available
     const isNativeCaptureAvailable = await checkIfNativeCaptureAvailable();
 
     if (isNativeCaptureAvailable) {
-      // Use Native Capture API through the background script
-      // if (loadingMessage) loadingMessage.hidden = true;
-
       const dataUrl = await captureTab();
-
-      // if (loadingMessage) loadingMessage.hidden = false;
-
-      // Process the screenshot from the Native Capture API
       return processScreenshot({ dataUrl, x, y, width, height, scaleFactor, mode });
     } else {
-      // Fallback to html2canvas logic
       const fullCanvas = await html2canvas(document.body, {
-        useCORS: true, // Ensures external resources don't block rendering
-        allowTaint: true, // Skips cross-origin restrictions
-        logging: false, // Disables debug logs
-        removeContainer: true, // Removes temporary DOM elements
-        scale: scaleFactor, // Increase the scale factor for higher resolution
+        useCORS: true,
+        allowTaint: true,
+        logging: false,
+        removeContainer: true,
+        scale: scaleFactor,
         scrollX: window.scrollX,
         scrollY: window.scrollY,
         x: window.scrollX,
@@ -495,7 +449,6 @@ const captureScreenshots = async ({
   }
 };
 
-// Helper: Process the screenshot
 const processScreenshot = async ({
   dataUrl,
   x,
@@ -525,13 +478,10 @@ const processScreenshot = async ({
   const ctx: CanvasRenderingContext2D | null = fullCanvas.getContext('2d');
   ctx?.drawImage(img, 0, 0);
 
-  // Crop the selected area
   const croppedCanvas = cropSelectedArea(fullCanvas, x, y, width, height, scaleFactor);
 
-  // Add a red boundary box on the full screenshot
   addBoundaryBox(fullCanvas, x, y, width, height, scaleFactor);
 
-  // Convert canvases to images
   let fullScreenshotImage: string | null = fullCanvas.toDataURL('image/jpeg', 1);
   let croppedScreenshotImage =
     croppedCanvas.width && croppedCanvas.height ? croppedCanvas.toDataURL('image/jpeg', 1) : null;
@@ -544,22 +494,17 @@ const processScreenshot = async ({
     mode,
   });
 
-  // Cleanup
   fullScreenshotImage = null;
   croppedScreenshotImage = null;
   croppedCanvas?.remove();
   fullCanvas?.remove();
 };
 
-// Save and notify with screenshots
 const saveAndNotify = ({ screenshots, mode }: { screenshots: Screenshot[]; mode: 'single' | 'multiple' }) => {
   const timestamp = Date.now();
   const screenshotName: string = `${location.host}-${timestamp}`.replaceAll('.', '-');
 
-  /**
-   * @todo use safePostMessage
-   * currently brakes the build (because of extend)
-   */
+  // Using window.postMessage rather than safePostMessage — the latter breaks the extend build.
   window.postMessage(
     {
       type: RECORD.ADD,
@@ -590,13 +535,8 @@ const saveAndNotify = ({ screenshots, mode }: { screenshots: Screenshot[]; mode:
   window.dispatchEvent(event);
 };
 
-// Initialization
 export const startScreenshotCapture = async ({
   type,
-  /**
-   * @todo
-   * add a toggle to choose the mode 'single' | 'multiple'
-   */
   mode = 'multiple',
 }: {
   type: 'full-page' | 'viewport' | 'area';
@@ -643,19 +583,13 @@ export const startScreenshotCapture = async ({
   showInstructions();
   hidePreview();
 
-  overlay.addEventListener('keydown', onKeyDown); // Listen for ESC key press
+  overlay.addEventListener('keydown', onKeyDown);
   overlay.addEventListener('mousedown', e => onMouseDown(e, mode));
   overlay.addEventListener('touchstart', e => onMouseDown(e, mode));
 };
 
-// Clean up all temporary elements
 export const cleanup = (): void => {
   isSelecting = false;
-
-  // Reset any necessary state
-  // startX = 0;
-  // startY = 0;
-  // cancelled = true;
 
   overlay?.remove();
   selectionBox?.remove();
@@ -666,9 +600,8 @@ export const cleanup = (): void => {
   document.body.style.overflow = '';
   document.removeEventListener('keydown', onKeyDown);
   document.removeEventListener('mousemove', updateSelectionBox);
-  // Also remove the cursor-tracking listeners attached by showInstructions(). Without these the
-  // listeners stayed on document for the page's lifetime after ESC/completion — each cancelled
-  // capture session leaked another pair.
+  // Cursor-tracking listeners attached by showInstructions() must be removed here — otherwise
+  // each cancelled capture session leaks another pair for the page's lifetime.
   document.removeEventListener('mousemove', onMouseMove);
   document.removeEventListener('touchmove', onTouchMove);
   if (selectionMouseUpHandler) {

--- a/pages/content/src/capture/video.capture.ts
+++ b/pages/content/src/capture/video.capture.ts
@@ -100,7 +100,7 @@ const cleanupMic = async () => {
       try {
         track.stop();
       } catch {
-        /* */
+        //
       }
     });
   }
@@ -110,7 +110,7 @@ const cleanupMic = async () => {
     recordingSettingsStorage.setMicActiveTrack(false),
     recordingSettingsStorage.setMicMuted(false),
   ]).catch(() => {
-    /* storage write failure is non-critical */
+    //
   });
 };
 
@@ -151,7 +151,8 @@ export const startCaptureNow = async () => {
 
     stream = await navigator.mediaDevices.getDisplayMedia(constraints);
 
-    // Remove any unexpected audio tracks from the display stream
+    // The display stream may include tab audio depending on user choice — strip it so the only
+    // audio source is the explicit mic stream below.
     stream.getAudioTracks().forEach(t => t.stop());
 
     let recordingStream = stream;
@@ -170,7 +171,6 @@ export const startCaptureNow = async () => {
           await recordingSettingsStorage.setMicActiveTrack(true);
           await recordingSettingsStorage.setMicMuted(false);
         } else {
-          // getUserMedia succeeded but returned no audio tracks — treat as failure
           micStream.getTracks().forEach(t => t.stop());
           micStream = null;
           await recordingSettingsStorage.setMicActiveTrack(false);
@@ -274,12 +274,6 @@ export const pauseRecording = () => {
         },
       }),
     );
-
-    /**
-     * @todo
-     * keep autoStop interval running or not? pause shouldn't consume budget anyway,
-     * but interval checks recordedMs so it's safe to keep running.
-     */
   } catch (e) {
     console.error('[brie | Recording] pause failed:', e);
     cleanup();

--- a/pages/content/src/event-listeners/runtime.event-listeners.ts
+++ b/pages/content/src/event-listeners/runtime.event-listeners.ts
@@ -22,16 +22,10 @@ export const addRuntimeEventListeners = () => {
     const { action, payload } = rawMessage;
 
     switch (action) {
-      /**
-       * Auth flow
-       */
       case AUTH.STATUS:
         window.dispatchEvent(new CustomEvent(AUTH.STATUS, { detail: payload }));
         break;
 
-      /**
-       * Screenshot capture flow
-       */
       case SCREENSHOT.START:
         window.dispatchEvent(new CustomEvent(UI.LAYOUT_RECALC));
         startScreenshotCapture(payload);
@@ -45,9 +39,6 @@ export const addRuntimeEventListeners = () => {
         window.dispatchEvent(new CustomEvent(UI.CLOSE_MODAL));
         break;
 
-      /**
-       * Video capture flow
-       */
       case RECORDING.START:
         beginPreparingRecording(payload);
         startCaptureNow();
@@ -69,9 +60,6 @@ export const addRuntimeEventListeners = () => {
         toggleMic();
         break;
 
-      /**
-       * Rewind capture flow
-       */
       case REWIND.SET_ENABLED:
         console.log('runtime: SET_ENABLED', rawMessage);
 

--- a/pages/content/src/event-listeners/window.event-listeners.ts
+++ b/pages/content/src/event-listeners/window.event-listeners.ts
@@ -6,23 +6,10 @@ const ERROR_NOTIFICATION_COOLDOWN_MS = 60_000;
 let lastErrorNotificationTimestamp = 0;
 
 export const addWindowEventListeners = () => {
-  /**
-   * If you're injecting JavaScript into the webpage (e.g., to override fetch), remember:
-   * The injected script does not have access to Chrome extension APIs (like chrome.runtime.sendMessage).
-   * To communicate, inject the script and use window.postMessage to send data back to the content script.
-   */
+  // Injected scripts have no access to chrome.* APIs; they communicate back via window.postMessage.
   window.addEventListener('message', (event: MessageEvent) => {
-    /**
-     * @todo
-     * - Must be namespaced to avoid page scripts spoofing controller commands
-     * if (event.data?.source !== 'brie-ui') return;
-     *
-     * - Guard using the allowed message types
-     * if (!ALLOWED_MESSAGE_TYPES.has(event.data.type)) return;
-     *
-     * - Use Enums
-     */
-
+    // SECURITY GAP: messages are not namespaced (no `event.data.source` check) and `type` is not
+    // validated against an allowlist, so page scripts could spoof controller commands.
     if (event.source !== window || !event.data.type) return;
 
     const { type } = event.data;
@@ -52,9 +39,6 @@ export const addWindowEventListeners = () => {
         break;
       }
 
-      /**
-       * Video capture flow
-       */
       case RECORDING.PAUSE:
         pauseRecording();
         break;

--- a/pages/content/src/interceptors/application/cookies.interceptor.ts
+++ b/pages/content/src/interceptors/application/cookies.interceptor.ts
@@ -5,7 +5,6 @@ interface Cookie {
   value: string;
 }
 
-// Get all cookies
 export const interceptCookies = () => {
   const timestamp = Date.now();
   const cookies: Cookie[] = document.cookie.split(';').reduce<Cookie[]>((ac, str) => {
@@ -13,7 +12,6 @@ export const interceptCookies = () => {
 
     if (!key) return ac;
 
-    // Add cookie as an object with key and value
     ac.push({
       key,
       value,

--- a/pages/content/src/interceptors/application/local-storage.interceptor.ts
+++ b/pages/content/src/interceptors/application/local-storage.interceptor.ts
@@ -1,13 +1,12 @@
 import { RECORD, safePostMessage } from '@extension/shared';
 
-// Get all localStorage data
 export const interceptLocalStorage = () => {
   const timestamp = Date.now();
   const localStorageData = [];
 
   for (let i = 0; i < localStorage.length; i++) {
     const key = localStorage.key(i);
-    if (!key) continue; // Skip null keys
+    if (!key) continue;
 
     const value = localStorage.getItem(key);
     localStorageData.push({

--- a/pages/content/src/interceptors/application/session-storage.interceptor.ts
+++ b/pages/content/src/interceptors/application/session-storage.interceptor.ts
@@ -1,13 +1,12 @@
 import { RECORD, safePostMessage } from '@extension/shared';
 
-// Get all sessionStorage data
 export const interceptSessionStorage = () => {
   const timestamp = Date.now();
   const sessionStorageData = [];
 
   for (let i = 0; i < sessionStorage.length; i++) {
     const key = sessionStorage.key(i);
-    if (!key) continue; // Skip null keys
+    if (!key) continue;
 
     const value = sessionStorage.getItem(key);
     sessionStorageData.push({

--- a/pages/content/src/interceptors/console/console.interceptor.ts
+++ b/pages/content/src/interceptors/console/console.interceptor.ts
@@ -57,7 +57,7 @@ export const interceptConsole = () => {
 
       safePostMessage(RECORD.ADD, logData);
     } catch {
-      // Don't throw or break host page
+      // Never throw from a console method override — would break the host page.
     }
   };
 
@@ -73,7 +73,7 @@ export const interceptConsole = () => {
         try {
           captureLog(method, args);
         } catch {
-          // Silently fail
+          //
         }
         original.apply(console, args);
       },

--- a/pages/content/src/interceptors/events/events.interceptor.ts
+++ b/pages/content/src/interceptors/events/events.interceptor.ts
@@ -27,11 +27,6 @@ const ENTER_SUBMIT_WINDOW_MS = 500;
 const ACTIVATION_KEYS = new Set(['Enter', ' ']);
 const pendingEnterSubmit = new WeakMap<HTMLFormElement, number>();
 
-/**
- * Handles value-carrying element changes (input/select/textarea).
- * @param event - The DOM event.
- * @param reason - Why it fired: 'change' | 'blur' | 'input'.
- */
 const handleOnValueChange = (event: Event, reason: 'change' | 'blur' | 'input') => {
   if (pathTouchesExtension(event)) return;
 
@@ -42,7 +37,6 @@ const handleOnValueChange = (event: Event, reason: 'change' | 'blur' | 'input') 
   const tag = target.tagName;
   const type = (target.getAttribute?.('type') || '').toLowerCase();
 
-  // Native select
   if (tag === 'SELECT') {
     const value = (target as HTMLSelectElement).value ?? null;
     const controlLabel = getAssociatedLabelText(target);
@@ -56,7 +50,6 @@ const handleOnValueChange = (event: Event, reason: 'change' | 'blur' | 'input') 
     return;
   }
 
-  // Checkbox/Radio: report checked & value
   if (tag === 'INPUT' && ['checkbox', 'radio'].includes(type)) {
     const el = target as HTMLInputElement;
 
@@ -69,7 +62,6 @@ const handleOnValueChange = (event: Event, reason: 'change' | 'blur' | 'input') 
     return;
   }
 
-  // Textual inputs/textarea on blur/change to avoid noise (input reason emits live if needed)
   if (['INPUT', 'TEXTAREA', 'SELECT'].includes(tag)) {
     const el = target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement;
     const value = (el as HTMLInputElement).value ?? (el as HTMLTextAreaElement).value ?? null;
@@ -79,10 +71,6 @@ const handleOnValueChange = (event: Event, reason: 'change' | 'blur' | 'input') 
   }
 };
 
-/**
- * Handles clicks on custom select options (e.g., role=option/menuitem).
- * @param event - Mouse click event.
- */
 const handleOnCustomSelectClick = (event: MouseEvent) => {
   const target = deepTarget(event);
 
@@ -97,7 +85,7 @@ const handleOnCustomSelectClick = (event: MouseEvent) => {
 
     sendEvent(
       AppEventType.SelectChange,
-      target, // control ?? target
+      target,
       pickDefined({
         value,
         source: 'custom',
@@ -107,10 +95,6 @@ const handleOnCustomSelectClick = (event: MouseEvent) => {
   }
 };
 
-/**
- * Handles mouse clicks using capture phase and composed path.
- * @param event - Mouse click event.
- */
 const handleOnClick = (event: MouseEvent) => {
   const ep = document.elementFromPoint(event.clientX, event.clientY);
   const hitTarget = ep instanceof Element ? ep : deepTarget(event);
@@ -120,10 +104,7 @@ const handleOnClick = (event: MouseEvent) => {
   const role = (hitTarget as HTMLElement).getAttribute?.('role')?.toLowerCase();
   const tag = hitTarget.tagName;
 
-  /**
-   * Ignore clicks inside native selects and ARIA listboxes/comboboxes;
-   * these are handled by change/option-click handlers below.
-   */
+  // Native selects and ARIA listboxes/comboboxes are handled by change/option-click — skip to avoid duplicates.
   if (tag === 'SELECT' || role === 'option' || role === 'listbox' || role === 'combobox') return;
   if (isClickWithinToggle(hitTarget, event)) return;
 
@@ -137,10 +118,6 @@ const handleOnClick = (event: MouseEvent) => {
   sendEvent(AppEventType.MouseClick, finalTarget);
 };
 
-/**
- * Handles clicks on ARIA toggles (role=checkbox|radio|switch).
- * Emits a single InputChange with inferred checked state.
- */
 const handleOnAriaToggleClick = (event: MouseEvent) => {
   const t = deepTarget(event);
   if (!(t instanceof HTMLElement)) return;
@@ -160,14 +137,7 @@ const handleOnAriaToggleClick = (event: MouseEvent) => {
   });
 };
 
-/**
- * Handles keyboard shortcuts and key-based activations (Enter/Space).
- * - No KeyActivation for Tab or Space while typing.
- * - Shortcuts emit only once per chord (ignores bare modifiers).
- * - Enter inside a FORM defers to FormSubmit (no KeyActivation).
- *
- * @param event - Submit event.
- */
+// Enter inside a FORM defers to handleOnSubmit (no KeyActivation) so the two don't double-fire.
 const handleOnKeydown = (event: KeyboardEvent) => {
   if (pathTouchesExtension(event)) return;
 
@@ -215,26 +185,16 @@ const handleOnKeydown = (event: KeyboardEvent) => {
   }
 };
 
-/**
- * Handles form submission events and emits a single FormSubmit.
- * - Suppresses duplicate KeyActivation events triggered by Enter inside forms.
- * - Captures action/method metadata from the form element.
- *
- * @param event - Submit event.
- */
 const handleOnSubmit = (event: Event) => {
   if (pathTouchesExtension(event)) return;
 
-  // Find the form element from the composed path (handles shadow DOM)
+  // composedPath() crosses shadow DOM; event.target may not.
   const path = (event.composedPath?.() ?? []) as EventTarget[];
   const form = path.find(n => n instanceof HTMLFormElement) as HTMLFormElement | null;
 
-  // Fallback: use the event target if no form found
   const el = form ?? (deepTarget(event) as Element | null);
   if (!el) return;
 
-  // If this was triggered by pressing Enter in a text input,
-  // and we recorded a pending KeyActivation recently → suppress it.
   if (form) {
     const ts = pendingEnterSubmit.get(form);
     if (ts && Date.now() - ts <= ENTER_SUBMIT_WINDOW_MS) {
@@ -242,7 +202,6 @@ const handleOnSubmit = (event: Event) => {
     }
   }
 
-  // Capture useful form metadata (if available)
   const extra = form
     ? {
         action: form.action || null,
@@ -253,10 +212,6 @@ const handleOnSubmit = (event: Event) => {
   sendEvent(AppEventType.FormSubmit, el, extra);
 };
 
-/**
- * Collects system metadata and emits a metadata event.
- * @returns Promise that resolves after metadata is sent.
- */
 const handleOnMetadata = async () => {
   const systemInfo = await getSystemInfo().catch(() => ({}));
 
@@ -274,18 +229,10 @@ const handleOnMetadata = async () => {
   );
 };
 
-/**
- * Collects video metadata and emits a video metadata event.
- * @returns Promise that resolves after metadata is sent.
- */
 const handleOnVideoMetadata = async (event: any) => {
   sendEvent(AppEventType.VideoMetadata, null, pickDefined(event.detail));
 };
 
-/**
- * Creates a visibilitychange handler that tracks hidden/visible and time away of opened tabs.
- * @returns A function to call on each visibilitychange.
- */
 const createTabVisibilityHandler = () => {
   let hiddenAt: number | null = null;
 
@@ -305,16 +252,6 @@ const createTabVisibilityHandler = () => {
   };
 };
 
-/**
- * Creates a debounced resize handler that emits a single event per resize activity.
- *
- * - Fires once after the user stops resizing the window (trailing debounce).
- * - Suppresses duplicate emissions if the final size matches the last emitted size.
- * - Provides `.flush()` to emit immediately and `.cancel()` to clear pending timers.
- *
- * @param idleMs - The debounce delay in milliseconds (default: 1000ms).
- * @returns A resize handler function with `flush()` and `cancel()` helpers attached.
- */
 const createResizeOncePerActivity = (idleMs = 1000): ResizeHandler => {
   let t: ReturnType<typeof setTimeout> | null = null;
   let pendingW = window.innerWidth;
@@ -363,7 +300,7 @@ let eventsInterceptorRegistered = false;
 
 const handleAllClicks = (event: MouseEvent) => {
   if (pathTouchesExtension(event)) return;
-  // Each handler is independently wrapped so a throw in one doesn't drop the others.
+  // Independently wrapped so a throw in one handler doesn't drop the others.
   try {
     handleOnClick(event);
   } catch (err) {
@@ -381,27 +318,21 @@ const handleAllClicks = (event: MouseEvent) => {
   }
 };
 
-/**
- * Initializes all capture-phase listeners and starts event interception.
- * Idempotent — re-running on an SPA navigation will not double-register.
- */
+/** Idempotent — re-running on an SPA navigation will not double-register. */
 export const interceptEvents = () => {
   if (eventsInterceptorRegistered) return;
   eventsInterceptorRegistered = true;
 
-  // Lifecycle
   document.addEventListener('DOMContentLoaded', () => sendEvent(AppEventType.DOMContentLoaded), {
     capture: true,
     passive: true,
   });
   window.addEventListener('load', () => sendEvent(AppEventType.PageLoaded), { capture: true, passive: true });
 
-  // Resize
   const onResize = createResizeOncePerActivity(1500);
   window.addEventListener('resize', onResize, { capture: true, passive: true });
   window.addEventListener('orientationchange', () => onResize.flush(), { capture: true, passive: true });
 
-  // Visibility
   const handleOnTabVisibilityChange = createTabVisibilityHandler();
   document.addEventListener(
     'visibilitychange',
@@ -413,27 +344,20 @@ export const interceptEvents = () => {
     { capture: true, passive: true },
   );
 
-  // Inputs / selects changes
   document.addEventListener('change', e => handleOnValueChange(e, 'change'), { capture: true });
 
   document.addEventListener('click', handleAllClicks, { capture: true });
 
-  // Keyboard
   document.addEventListener('keydown', handleOnKeydown, { capture: true });
 
-  // Submit
   document.addEventListener('submit', handleOnSubmit, { capture: true });
 
-  // Custom metadata event
   window.addEventListener(UI.LAYOUT_RECALC, handleOnMetadata as EventListener, { capture: true });
 
-  // Custom video metadata event
   window.addEventListener(VIDEO.METADATA, handleOnVideoMetadata as EventListener, { capture: true });
 
-  // History
   historyApiInterceptor();
 
-  // Media
   const mediaEvents: Array<keyof HTMLMediaElementEventMap> = ['play', 'pause', 'volumechange'];
 
   for (const event of mediaEvents) {

--- a/pages/content/src/interceptors/network/fetch.interceptor.ts
+++ b/pages/content/src/interceptors/network/fetch.interceptor.ts
@@ -5,9 +5,9 @@ import { extractQueryParams } from '@src/utils';
 import { REDACT_BODY_KEYS, redactHeaderValue } from './redact.util.js';
 
 type FetchArgs = [RequestInfo | URL, RequestInit?];
-const MAX_BODY_BYTES = 100_000; // 100KB cap for request/response previews
+const MAX_BODY_BYTES = 100_000;
 const BINARY_CT = /(octet-stream|pdf|zip|gzip|image|audio|video)\b/i;
-const SELF_ENDPOINT_REGEX = /\/add-record|\/telemetry|\/analytics/; // adjust to your endpoints
+const SELF_ENDPOINT_REGEX = /\/add-record|\/telemetry|\/analytics/;
 
 const truncate = (s: string, max = MAX_BODY_BYTES) => (s.length > max ? s.slice(0, max) + '…[truncated]' : s);
 
@@ -39,7 +39,6 @@ const previewRequestBodyFromRequest = async (req: Request): Promise<{ text?: str
   try {
     if (req.bodyUsed) return { text: '[unavailable: body already used]' };
     const clone = req.clone();
-    // If no body, this resolves empty string
     const text = await clone.text();
     if (!text) return {};
     return previewRequestBodyFromInit(text);
@@ -53,7 +52,6 @@ const previewRequestBodyFromInit = (body?: BodyInit | null): { text?: string; by
   try {
     if (typeof body === 'string') {
       const trimmed = body.trim();
-      // try redact JSON keys if JSON-like
       if ((trimmed.startsWith('{') && trimmed.endsWith('}')) || (trimmed.startsWith('[') && trimmed.endsWith(']'))) {
         try {
           const obj = JSON.parse(trimmed);
@@ -75,7 +73,7 @@ const previewRequestBodyFromInit = (body?: BodyInit | null): { text?: string; by
           const redacted = JSON.stringify(redact(obj));
           return { text: truncate(redacted), bytes: redacted.length };
         } catch {
-          /* fallthrough */
+          //
         }
       }
       return { text: truncate(body), bytes: body.length };
@@ -106,7 +104,7 @@ const previewRequestBodyFromInit = (body?: BodyInit | null): { text?: string; by
     if (body instanceof ArrayBuffer) return { text: `[arraybuffer:${body.byteLength}B]`, bytes: body.byteLength };
     if ((body as any).stream) return { text: '[stream]' };
   } catch {
-    /* ignore */
+    //
   }
   return { text: '[unserializable body]' };
 };
@@ -126,7 +124,6 @@ export const interceptFetch = (): void => {
     const startISO = new Date().toISOString();
     const startPerf = performance.now();
 
-    // Normalize URL
     let urlStr: string;
     let req: Request | undefined;
     let init: RequestInit | undefined;
@@ -141,32 +138,26 @@ export const interceptFetch = (): void => {
         init = args[1] || {};
       }
     } catch {
-      // fallback
       urlStr = String(args[0]);
     }
 
-    // Skip non-http(s) & self endpoints
     if (!/^https?:\/\//i.test(urlStr) || SELF_ENDPOINT_REGEX.test(urlStr)) {
       return originalFetch.apply(this, args as any);
     }
 
     const method = (req?.method || init?.method || 'GET').toUpperCase();
 
-    // Request headers
     const outgoingHeaders = req ? headersInitToRecord(req.headers) : headersInitToRecord(init?.headers);
     const requestHeaders = redactHeaders(outgoingHeaders);
 
-    // Request body preview
     const bodyPreview = req ? await previewRequestBodyFromRequest(req) : previewRequestBodyFromInit(init?.body ?? null);
 
-    // Query params (your helper)
     const queryParams = extractQueryParams(urlStr);
 
     let response: Response;
     try {
       response = await originalFetch.apply(this, args as any);
     } catch (err) {
-      // Network error (no Response)
       const endISO = new Date().toISOString();
       const durationMs = performance.now() - startPerf;
 
@@ -204,13 +195,12 @@ export const interceptFetch = (): void => {
         url: urlStr,
       });
 
-      throw err; // preserve behavior
+      throw err;
     }
 
     const endISO = new Date().toISOString();
     const durationMs = performance.now() - startPerf;
 
-    // Opaque / CORS no-cors responses
     if (response.type === 'opaque') {
       safePostMessage(RECORD.ADD, {
         domain: 'fetch',
@@ -235,7 +225,6 @@ export const interceptFetch = (): void => {
       return response;
     }
 
-    // Normal responses: clone and read safely
     const ct = response.headers.get('Content-Type');
     const looksBinary = isBinaryContentType(ct);
     const clone = response.clone();
@@ -248,12 +237,12 @@ export const interceptFetch = (): void => {
       if (looksBinary) {
         responseBody = `[binary:${serializedHeaders['content-length'] ?? '?'}B]`;
       } else if (ct?.includes('application/json')) {
-        const text = await clone.text(); // read text first to cap
+        const text = await clone.text();
         const capped = truncate(text);
         try {
           responseBody = JSON.parse(capped);
         } catch {
-          responseBody = capped; // malformed JSON → keep as text
+          responseBody = capped;
         }
       } else if (ct?.includes('text') || ct?.includes('xml')) {
         const text = await clone.text();

--- a/pages/content/src/interceptors/network/redact.util.ts
+++ b/pages/content/src/interceptors/network/redact.util.ts
@@ -19,10 +19,6 @@ const redactObject = (obj: unknown): unknown => {
   return obj;
 };
 
-/**
- * Attempts to parse a string as JSON and redact sensitive keys.
- * Returns the original value if parsing fails or input is not a string.
- */
 const redactSensitiveBodyKeys = (body: unknown): unknown => {
   if (typeof body !== 'string') return body;
 

--- a/pages/content/src/interceptors/network/xhr.interceptor.ts
+++ b/pages/content/src/interceptors/network/xhr.interceptor.ts
@@ -2,7 +2,6 @@ import { RECORD, safePostMessage } from '@extension/shared';
 
 import { redactHeaderValue, redactSensitiveBodyKeys } from './redact.util.js';
 
-// Define interfaces for request details and payload
 interface RequestDetails {
   method: string;
   url: string;
@@ -10,17 +9,14 @@ interface RequestDetails {
   requestBody: Document | XMLHttpRequestBodyInit | null;
 }
 
-// Extend the XMLHttpRequest type to include custom properties
 interface ExtendedXMLHttpRequest extends XMLHttpRequest {
   _requestDetails?: RequestDetails;
 }
 
-// XMLHttpRequest Interceptor
 export const interceptXHR = (): void => {
   const originalOpen = XMLHttpRequest.prototype.open;
   const originalSend = XMLHttpRequest.prototype.send;
 
-  // Intercept XMLHttpRequest open method
   XMLHttpRequest.prototype.open = function (
     this: ExtendedXMLHttpRequest,
     method: string,
@@ -36,7 +32,6 @@ export const interceptXHR = (): void => {
     originalOpen.apply(this, [method, url, ...rest] as Parameters<XMLHttpRequest['open']>);
   };
 
-  // Intercept XMLHttpRequest send method
   XMLHttpRequest.prototype.send = function (
     this: ExtendedXMLHttpRequest,
     body?: Document | XMLHttpRequestBodyInit | null,
@@ -49,7 +44,6 @@ export const interceptXHR = (): void => {
     // the page assigns to xhr.onreadystatechange AFTER calling .send() is silently dropped.
     const onReadyStateChange = function (this: ExtendedXMLHttpRequest): void {
       if (this.readyState === 4 && this._requestDetails) {
-        // Request completed
         const endTime = new Date().toISOString();
         const rawHeaders = this.getAllResponseHeaders();
         const responseHeaders = rawHeaders
@@ -63,21 +57,18 @@ export const interceptXHR = (): void => {
 
         const requestBody = redactSensitiveBodyKeys(this._requestDetails.requestBody);
 
-        // Check for large or binary content (skip cloning and parsing for binary data)
         const contentType = this.getResponseHeader('Content-Type');
         const isBinary =
           contentType?.includes('application/octet-stream') ||
           contentType?.includes('image') ||
           contentType?.includes('audio');
         const isLargeResponse =
-          this.getResponseHeader('Content-Length') && parseInt(this.getResponseHeader('Content-Length')!, 10) > 1000000; // Arbitrary 1MB size limit
+          this.getResponseHeader('Content-Length') && parseInt(this.getResponseHeader('Content-Length')!, 10) > 1000000;
 
         let responseBody: string;
         if (isBinary || isLargeResponse) {
-          // Don't clone large or binary responses
           responseBody = 'BRIE: Binary or Large content - Unable to display';
         } else {
-          // Parse the response as JSON or text for non-binary/small responses
           try {
             responseBody = this.responseText || 'BRIE: No response body';
           } catch (error) {
@@ -86,7 +77,6 @@ export const interceptXHR = (): void => {
           }
         }
 
-        // Ensure message posting is supported
         try {
           if (typeof window !== 'undefined') {
             const timestamp = Date.now();

--- a/pages/content/src/utils/events/build-chord.util.ts
+++ b/pages/content/src/utils/events/build-chord.util.ts
@@ -1,13 +1,6 @@
 import { isModifier } from './is-modifier.util';
 
-/**
- * Builds a normalized shortcut chord (e.g., "Ctrl+Meta+K") or null for bare modifiers.
- * Uppercases single-letter base keys and preserves named keys (Enter, Escape, ArrowLeft, etc.).
- * @param e - Keyboard event to inspect.
- * @returns The chord string, or null if only a modifier was pressed.
- */
 export const buildChord = (e: KeyboardEvent): string | null => {
-  // ignore bare modifiers
   if (isModifier(e.key)) return null;
 
   const parts: string[] = [];

--- a/pages/content/src/utils/events/build-descriptor.util.ts
+++ b/pages/content/src/utils/events/build-descriptor.util.ts
@@ -4,12 +4,6 @@ import { getAssociatedLabelText } from './get-associated-label.util';
 import { pickAttr } from './pick-attr.util';
 import { pickDefined } from './pick-defined.util';
 
-/**
- * Creates a stable, minimal descriptor for an element.
- * Adds common attributes used for identification while avoiding duplicates.
- * @param el - Element to describe (supports null/null).
- * @returns An ElementDescriptor or null if no element.
- */
 export const buildDescriptor = (el?: Element | null): ElementDescriptor | null => {
   if (!el) return null;
 

--- a/pages/content/src/utils/events/closest-form.util.ts
+++ b/pages/content/src/utils/events/closest-form.util.ts
@@ -1,8 +1,3 @@
-/**
- * Finds the closest ancestor <form> for an element.
- * @param el - Starting element (may be null).
- * @returns The nearest HTMLFormElement, or null if none.
- */
 export const closestForm = (el: Element | null): HTMLFormElement | null => {
   for (let n = el; n; n = n.parentElement) if (n instanceof HTMLFormElement) return n;
 

--- a/pages/content/src/utils/events/collect-label-candidates.util.ts
+++ b/pages/content/src/utils/events/collect-label-candidates.util.ts
@@ -1,4 +1,3 @@
-/** Collect best candidates that might carry the id/role linkage for labeling. */
 export const collectLabelCandidates = (el: Element): HTMLElement[] => {
   const cands: Set<HTMLElement> = new Set();
 
@@ -8,20 +7,18 @@ export const collectLabelCandidates = (el: Element): HTMLElement[] => {
 
   push(el);
 
-  // 1) The closest element that already has an id (often a wrapper/input in custom UIs)
   push(el.closest?.('[id]'));
 
-  // 2) Role containers typical for custom selects
   push(el.closest?.('[role="combobox"]'));
   push(el.closest?.('[role="listbox"]'));
   push(el.closest?.('[role="textbox"]'));
 
-  // 3) First focusable/real control inside this subtree
   push(
     el.querySelector?.('input[id], select[id], textarea[id], button[id], [role="combobox"][id], [role="textbox"][id]'),
   );
 
-  // 4) For React-Select style containers, find the input with id inside the container
+  // React-Select renders the real <input> inside a wrapper class — without this, the visible
+  // combobox div has no usable id.
   const reactSelectRoot = el.closest?.('.react-select-container');
   push(reactSelectRoot?.querySelector?.('input[id]'));
 

--- a/pages/content/src/utils/events/deep-target.util.ts
+++ b/pages/content/src/utils/events/deep-target.util.ts
@@ -1,8 +1,4 @@
-/**
- * Returns the first Element from the event's composed path.
- * @param event - The DOM event (works with Shadow DOM).
- * @returns The deepest Element target, or null if none.
- */
+/** Composed path crosses Shadow DOM; event.target may not. */
 export const deepTarget = (event: Event): Element | null => {
   const path = (event.composedPath?.() ?? []) as Array<EventTarget>;
 

--- a/pages/content/src/utils/events/element-clickable.util.ts
+++ b/pages/content/src/utils/events/element-clickable.util.ts
@@ -1,17 +1,5 @@
 import { CLICKABLE_TAGS } from '@src/constants';
 
-/**
- * Determines whether a given element is considered clickable.
- *
- * This includes:
- * - Native interactive elements like <a>, <button>, <input>
- * - Elements with specific roles like 'button', 'link', 'option'
- * - Elements with a tabindex or a click handler
- * - Elements with a 'cursor-pointer' class
- *
- * @param element - The element to check.
- * @returns True if the element is considered clickable, false otherwise.
- */
 export const isClickableElement = (element: HTMLElement | null): boolean => {
   if (!element) return false;
 

--- a/pages/content/src/utils/events/element-description.util.ts
+++ b/pages/content/src/utils/events/element-description.util.ts
@@ -1,29 +1,24 @@
-// Function to get description from an element (supports label, input, etc.)
 export const getElementDescription = (element: Element | null) => {
   let description = null;
 
   if (!(element instanceof HTMLElement) || ['BODY', 'DIV'].includes(element?.tagName)) {
-    return description; // Ensure element is a valid DOM element
+    return description;
   }
 
-  // Check if the element is wrapped inside a label
   const label = element?.closest('label');
 
   if (label) {
     description = label.innerText || label.getAttribute('aria-label');
   }
 
-  // Check for relevant ARIA attributes directly on the element
   if (!description) {
     const ariaLabel = element.getAttribute('aria-label');
     const ariaDescribedBy = element.getAttribute('aria-describedby');
     const ariaRole = element.getAttribute('role');
 
-    // Combine the ARIA attributes into a descriptive string
     description = ariaLabel || ariaDescribedBy || ariaRole;
   }
 
-  // If no ARIA attributes or labels are found, fallback to the element's inner text or a generic description
   if (!description) {
     description = element.innerText || element.getAttribute('title');
   }

--- a/pages/content/src/utils/events/find-clickable-element.util.ts
+++ b/pages/content/src/utils/events/find-clickable-element.util.ts
@@ -1,27 +1,15 @@
 import { isClickableElement } from './element-clickable.util';
 import { findReactProp } from './find-react-prop.util';
 
-/**
- * Traverses up to a fixed depth from a DOM element to find the closest clickable parent.
- *
- * A clickable parent is defined as:
- * - An element that passes `isClickableElement()`
- * - Optionally, an element backed by a React event prop (but returns the DOM element, not the prop)
- *
- * @param element - The starting DOM element (e.g., from an event target)
- * @param maxDepth - Maximum number of parent levels to search (default: 5)
- * @returns The first clickable HTMLElement found, or null if none found
- */
 export const findClickableParent = (element: HTMLElement | null, maxDepth: number = 5): HTMLElement | null => {
   let current = element?.parentElement ?? null;
   let depth = 0;
 
   while (current && depth < maxDepth) {
     if (isClickableElement(current)) {
-      // Check for React synthetic props but still return the DOM node
       const reactProp = findReactProp(current);
 
-      return reactProp ? (current as any)[reactProp] : current; // Return the first clickable ancestor found
+      return reactProp ? (current as any)[reactProp] : current;
     }
 
     current = current.parentElement;

--- a/pages/content/src/utils/events/find-clickable-path.util.ts
+++ b/pages/content/src/utils/events/find-clickable-path.util.ts
@@ -1,11 +1,6 @@
 import { deepTarget } from './deep-target.util';
 import { isClickable } from './is-clickable.util';
 
-/**
- * Finds the first clickable element in the event path or ancestor chain.
- * @param event - The DOM event (uses composedPath and fallback parent walk).
- * @returns The first clickable Element or null.
- */
 export const findClickableInPath = (event: Event): Element | null => {
   const paths = (event.composedPath?.() ?? []) as Array<EventTarget>;
 

--- a/pages/content/src/utils/events/find-react-prop.util.ts
+++ b/pages/content/src/utils/events/find-react-prop.util.ts
@@ -1,11 +1,5 @@
 export const findReactProp = (element: Element) => {
-  // Get all property names on the element
   const props = Object.keys(element);
-
-  // Find the property that matches the React Fiber naming pattern
   const reactProp = props.find(prop => prop.startsWith('__reactProps$'));
-
-  // Return the value of the matching property, or null if not found
-  //? element[reactProp] : null;
   return reactProp;
 };

--- a/pages/content/src/utils/events/find-select-control-option.util.ts
+++ b/pages/content/src/utils/events/find-select-control-option.util.ts
@@ -1,16 +1,4 @@
-/**
- * Finds the parent control element associated with an option in a custom select/listbox.
- *
- * Search order:
- * 1. Closest ancestor with role=listbox/combobox/menu
- * 2. `aria-controls` or `aria-owns` references
- * 3. Closest button or element with aria-haspopup
- *
- * @param el - Option element inside a custom select component.
- * @returns The associated control element, or null if not found.
- */
 export const findSelectControlForOption = (el: Element): HTMLElement | null => {
-  // 1) ARIA: closest role=listbox/combobox
   let n: HTMLElement | null = el as HTMLElement;
 
   while (n) {
@@ -20,7 +8,6 @@ export const findSelectControlForOption = (el: Element): HTMLElement | null => {
     n = n.parentElement;
   }
 
-  // 2) aria-controls / aria-owns relationship (option -> listbox id)
   const listId = (el as HTMLElement).getAttribute('aria-controls') || (el as HTMLElement).getAttribute('aria-owns');
 
   if (listId) {
@@ -29,7 +16,6 @@ export const findSelectControlForOption = (el: Element): HTMLElement | null => {
     if (list instanceof HTMLElement) return list;
   }
 
-  // 3) Fallback: button that opened the popup (common pattern)
   const button = (el as HTMLElement).closest('[aria-haspopup="listbox"],[aria-haspopup="menu"],button');
 
   return (button as HTMLElement) || null;

--- a/pages/content/src/utils/events/get-associated-label.util.ts
+++ b/pages/content/src/utils/events/get-associated-label.util.ts
@@ -3,21 +3,13 @@ import { readText } from './read-text.util';
 import { cssEscape } from './safe-css-escape.util';
 
 /**
- * Resolves a human label for a control (native or custom).
- * Priority:
- * 1) aria-labelledby (on candidates)
- * 2) <label for="id"> (for any candidate with id)
- * 3) wrapping <label> ancestor
- * 4) nearest <legend> of enclosing <fieldset>
- * 5) heuristic siblings: explicit <label>, or label-like siblings/data-label/aria-label
- *
- * @param el - The element you’re describing (may be a child wrapper; function finds real control too).
- * @returns The resolved label text or null.
+ * Resolves a human label for a control (native or custom). Resolution order:
+ *   1) aria-labelledby   2) <label for="id">   3) wrapping <label>
+ *   4) <legend> of enclosing <fieldset>        5) heuristic siblings   6) own aria-label
  */
 export const getAssociatedLabelText = (el: Element): string | null => {
   const candidates = collectLabelCandidates(el);
 
-  // 1) aria-labelledby on any candidate
   for (const c of candidates) {
     const labelledBy = c.getAttribute?.('aria-labelledby');
     if (labelledBy) {
@@ -33,7 +25,6 @@ export const getAssociatedLabelText = (el: Element): string | null => {
     }
   }
 
-  // 2) <label for="id"> using any candidate with id
   for (const c of candidates) {
     const id = c.id;
     if (!id) continue;
@@ -42,14 +33,12 @@ export const getAssociatedLabelText = (el: Element): string | null => {
     if (t) return t;
   }
 
-  // 3) wrapping <label> (for any candidate)
   for (const c of candidates) {
     const wrapping = c.closest?.('label');
     const tWrap = readText(wrapping);
     if (tWrap) return tWrap;
   }
 
-  // 4) nearest <legend> within enclosing <fieldset> (for any candidate)
   for (const c of candidates) {
     const fs = c.closest?.('fieldset');
     const legend = fs?.querySelector?.(':scope > legend');
@@ -57,15 +46,12 @@ export const getAssociatedLabelText = (el: Element): string | null => {
     if (tLegend) return tLegend;
   }
 
-  // 5) Heuristic siblings of primary candidate (first in set)
   const primary = candidates[0];
   if (primary?.parentElement) {
-    // explicit <label> sibling
     const sibLabel = primary.parentElement.querySelector?.(':scope > label');
     const tSib = readText(sibLabel);
     if (tSib) return tSib;
 
-    // label-like siblings
     const likely = primary.parentElement.querySelector?.(
       ':scope > [data-label], :scope > [aria-label], :scope > .label, :scope > [class*="label"]',
     ) as HTMLElement | null;
@@ -73,7 +59,6 @@ export const getAssociatedLabelText = (el: Element): string | null => {
     if (tLikely) return tLikely;
   }
 
-  // Fallback: own aria-label on any candidate
   for (const c of candidates) {
     const ownAria = c.getAttribute?.('aria-label');
     if (ownAria && ownAria.trim()) return ownAria.trim();

--- a/pages/content/src/utils/events/get-option-text.util.ts
+++ b/pages/content/src/utils/events/get-option-text.util.ts
@@ -1,16 +1,3 @@
-/**
- * Extracts a readable value for a custom select option element.
- *
- * Extraction priority:
- * 1. `data-value`
- * 2. `aria-label`
- * 3. `innerText` / `textContent`
- *
- * Trims whitespace and truncates to 120 characters.
- *
- * @param opt - The option element.
- * @returns The extracted text value or null if empty.
- */
 export const getOptionText = (opt: HTMLElement): string | null => {
   const raw =
     opt.getAttribute('data-value') || opt.getAttribute('aria-label') || opt.innerText || opt.textContent || '';

--- a/pages/content/src/utils/events/is-click-toggle.util.ts
+++ b/pages/content/src/utils/events/is-click-toggle.util.ts
@@ -1,14 +1,10 @@
-/** True if the click occurs in or targets a checkbox/radio/switch control (native or custom). */
 export const isClickWithinToggle = (el: Element | null, evt?: MouseEvent): boolean => {
   if (!el) return false;
 
-  // A) Native inputs nearby
   if (el.closest('input[type="checkbox"], input[type="radio"]')) return true;
 
-  // B) ARIA toggles
   if (el.closest('[role="checkbox"], [role="radio"], [role="switch"]')) return true;
 
-  // C) Label → input association
   const label = el.closest('label[for]') as HTMLLabelElement | null;
   if (label?.htmlFor) {
     const ctl = document.getElementById(label.htmlFor) as HTMLInputElement | null;
@@ -17,7 +13,8 @@ export const isClickWithinToggle = (el: Element | null, evt?: MouseEvent): boole
     }
   }
 
-  // D) Hit-tested input under cursor (covers overlays/pointer-events tricks)
+  // Hit-test under the cursor — covers overlays / pointer-events tricks where the visible toggle
+  // is not the composedPath target.
   if (evt) {
     const ep = document.elementFromPoint(evt.clientX, evt.clientY);
     if (ep && ep instanceof HTMLElement && ep.closest('input[type="checkbox"], input[type="radio"]')) return true;

--- a/pages/content/src/utils/events/is-clickable.util.ts
+++ b/pages/content/src/utils/events/is-clickable.util.ts
@@ -1,8 +1,3 @@
-/**
- * Determines if an element is likely user-clickable.
- * @param el - Element to test (nullable).
- * @returns True if clickable; otherwise false.
- */
 export const isClickable = (el: Element | null): boolean => {
   if (!el) return false;
 

--- a/pages/content/src/utils/events/is-fn-key.util.ts
+++ b/pages/content/src/utils/events/is-fn-key.util.ts
@@ -1,6 +1,1 @@
-/**
- * Checks if a key represents a function key (e.g., F1–F24).
- * @param k - KeyboardEvent.key value.
- * @returns True if the key is a function key; otherwise false.
- */
 export const isFnKey = (k: string) => /^F\d+$/i.test(k);

--- a/pages/content/src/utils/events/is-interactive.util.ts
+++ b/pages/content/src/utils/events/is-interactive.util.ts
@@ -1,28 +1,9 @@
-/**
- * Determines whether an element is visible in layout via a non-zero bounding box.
- *
- * @param el - The element to evaluate.
- * @returns True if visible; otherwise false.
- */
 const isVisibleBox = (el: Element): boolean => {
   const r = (el as HTMLElement).getBoundingClientRect?.();
-  if (!r) return true; // be permissive if no layout info
+  if (!r) return true; // permissive when layout info is missing
   return r.width > 0 && r.height > 0;
 };
 
-/**
- * Determines whether an element is likely custom-interactive based on heuristics.
- *
- * Heuristics:
- * - Cursor is pointer
- * - Tabindex ≥ 0
- * - Interactive ARIA roles (e.g., button, option, link)
- * - ARIA interaction attributes (`aria-expanded`, `aria-pressed`, etc.)
- * - Draggable elements
- *
- * @param el - HTMLElement to evaluate.
- * @returns True if heuristically clickable; otherwise false.
- */
 const isHeuristicallyClickable = (el: HTMLElement): boolean => {
   const role = el.getAttribute('role')?.toLowerCase();
   const tabIndexAttr = el.getAttribute('tabindex');
@@ -30,7 +11,6 @@ const isHeuristicallyClickable = (el: HTMLElement): boolean => {
 
   if (tabIndex !== undefined && Number.isFinite(tabIndex) && tabIndex >= 0) return true;
 
-  // Common interactive ARIA roles (covers many custom components)
   if (
     role &&
     [
@@ -52,12 +32,10 @@ const isHeuristicallyClickable = (el: HTMLElement): boolean => {
   )
     return true;
 
-  // ARIA interaction hints often present on collapsibles/toggles
   if (el.hasAttribute('aria-expanded') || el.hasAttribute('aria-pressed') || el.hasAttribute('aria-selected')) {
     return true;
   }
 
-  // Draggable often implies interaction
   if ((el as unknown as { draggable?: boolean }).draggable === true || el.getAttribute('draggable') === 'true') {
     return true;
   }
@@ -65,14 +43,6 @@ const isHeuristicallyClickable = (el: HTMLElement): boolean => {
   return false;
 };
 
-/**
- * Determines whether an element is meaningfully interactive.
- * Accepts native controls and custom interactive DIVs (cursor:pointer, tabindex≥0, ARIA roles/states).
- * Filters out <html>/<body>, invisible boxes, and background containers.
- *
- * @param el - Element to evaluate (nullable).
- * @returns true if interactive; otherwise false.
- */
 export const isInteractive = (el: Element | null): boolean => {
   if (!el || el === document.body || el === document.documentElement) return false;
   if (!isVisibleBox(el)) return false;
@@ -81,7 +51,6 @@ export const isInteractive = (el: Element | null): boolean => {
   const tag = h.tagName;
   const type = h.getAttribute?.('type')?.toLowerCase();
 
-  // Native interactive tags
   if (['A', 'BUTTON', 'INPUT', 'SELECT', 'TEXTAREA', 'SUMMARY', 'LABEL', 'DETAILS'].includes(tag)) return true;
   if (
     tag === 'INPUT' &&
@@ -108,10 +77,8 @@ export const isInteractive = (el: Element | null): boolean => {
   )
     return true;
 
-  // Direct handler (inline onclick) – keep for legacy pages
   if (typeof (h as any).onclick === 'function') return true;
 
-  // Custom clickable DIVs/spans via heuristics
   if (isHeuristicallyClickable(h)) return true;
 
   return false;

--- a/pages/content/src/utils/events/is-modifier.util.ts
+++ b/pages/content/src/utils/events/is-modifier.util.ts
@@ -1,8 +1,3 @@
 const MOD_KEYS = new Set(['Control', 'Meta', 'Alt', 'Shift']);
 
-/**
- * Checks if a key is a modifier (Control, Meta, Alt, or Shift).
- * @param k - KeyboardEvent.key value.
- * @returns True if the key is a modifier; otherwise false.
- */
 export const isModifier = (k: string) => MOD_KEYS.has(k);

--- a/pages/content/src/utils/events/is-text-entry.util.ts
+++ b/pages/content/src/utils/events/is-text-entry.util.ts
@@ -1,15 +1,3 @@
-/**
- * Checks if an element is a text-entry control.
- *
- * Text-entry controls include:
- * - Text-like `<input>` types (text, search, email, etc.)
- * - `<textarea>`
- * - Elements with contenteditable=true
- * - Elements with ARIA roles like textbox or combobox
- *
- * @param el - The element to evaluate.
- * @returns True if the element allows text input; otherwise false.
- */
 export const isTextEntry = (el: Element | null): boolean => {
   if (!el) return false;
   const h = el as HTMLElement;
@@ -21,7 +9,6 @@ export const isTextEntry = (el: Element | null): boolean => {
 
   if (tag === 'TEXTAREA') return true;
   if (tag === 'INPUT') {
-    // non-text inputs are explicitly excluded
     if (
       [
         'checkbox',
@@ -38,7 +25,7 @@ export const isTextEntry = (el: Element | null): boolean => {
       ].includes(type)
     )
       return false;
-    return true; // text, search, email, number, password, tel, url, etc.
+    return true;
   }
   return role === 'textbox' || role === 'combobox';
 };

--- a/pages/content/src/utils/events/path-extension.util.ts
+++ b/pages/content/src/utils/events/path-extension.util.ts
@@ -1,10 +1,5 @@
 import { isExtensionElement } from '@extension/shared';
 
-/**
- * Checks whether any node in the event's composed path is part of the extension UI.
- * @param event - The DOM event to inspect.
- * @returns True if the path contains an extension element; otherwise false.
- */
 export const pathTouchesExtension = (event: Event): boolean => {
   const path = (event.composedPath?.() ?? []) as Array<EventTarget>;
 

--- a/pages/content/src/utils/events/pick-attr.util.ts
+++ b/pages/content/src/utils/events/pick-attr.util.ts
@@ -1,9 +1,3 @@
-/**
- * Gets the first non-empty value among the given attribute names on an element.
- * @param el - Target element to read attributes from.
- * @param names - Attribute names to check in order.
- * @returns The trimmed value if found; otherwise null.
- */
 export const pickAttr = (el: Element, names: string[]): string | null => {
   for (const n of names) {
     const v = (el as HTMLElement).getAttribute?.(n) ?? (el as any)[n];

--- a/pages/content/src/utils/events/pick-defined.util.ts
+++ b/pages/content/src/utils/events/pick-defined.util.ts
@@ -1,9 +1,3 @@
-/**
- * Returns a shallow copy with only defined (non-null/null) fields.
- * @typeParam T - Object type to filter.
- * @param obj - Source object.
- * @returns A new object containing only defined properties.
- */
 type NonNullable_<T> = { [K in keyof T]: Exclude<T[K], null | undefined> };
 
 export const pickDefined = <T extends Record<string, unknown>>(obj: T): NonNullable_<T> => {

--- a/pages/content/src/utils/events/read-text.util.ts
+++ b/pages/content/src/utils/events/read-text.util.ts
@@ -1,4 +1,3 @@
-/** Return trimmed text (bounded), ignoring excessive whitespace. */
 export const readText = (el: Element | null, max = 120): string | null => {
   if (!el) return null;
   const txt = ((el as HTMLElement).innerText || el.textContent || '').replace(/\s+/g, ' ').trim();

--- a/pages/content/src/utils/events/safe-css-escape.util.ts
+++ b/pages/content/src/utils/events/safe-css-escape.util.ts
@@ -1,4 +1,3 @@
-/** Safe CSS.escape fallback for older engines. */
 export const cssEscape = (s: string) =>
   (window as any).CSS?.escape
     ? (window as any).CSS.escape(s)

--- a/pages/content/src/utils/events/send-event.util.ts
+++ b/pages/content/src/utils/events/send-event.util.ts
@@ -6,13 +6,6 @@ import type { TrackedEvent } from '@src/interfaces';
 import { buildDescriptor } from './build-descriptor.util';
 import { pickDefined } from './pick-defined.util';
 
-/**
- * Emits a structured tracking event.
- * @param event - Event name.
- * @param el - Related element (optional).
- * @param extra - Additional fields to include (optional).
- * @returns void
- */
 export const sendEvent = (event: AppEventType, el?: Element | null, extra?: Record<string, unknown>) => {
   const baseTimestamp = Date.now();
   const timestamp = event === AppEventType.Navigate ? baseTimestamp + 1000 : baseTimestamp;

--- a/pages/content/src/utils/events/should-skip-click.util.ts
+++ b/pages/content/src/utils/events/should-skip-click.util.ts
@@ -1,32 +1,18 @@
-/**
- * Determines whether a click event should be skipped from tracking.
- *
- * Skips clicks that occur on:
- * 1. Editable form elements (e.g., input, textarea, contenteditable)
- * 2. Elements inside decorated input wrappers (e.g., icons, labels, wrappers around inputs)
- *
- * @param {HTMLElement} target - The element that was clicked.
- * @returns {boolean} True if the click should be skipped; otherwise, false.
- */
 export const shouldSkipClick = (target: HTMLElement): boolean => {
   const tagName = target.tagName.toUpperCase();
   const inputType = target.getAttribute('type')?.toLowerCase();
 
-  // Skip native checkboxes/radios
   if (tagName === 'INPUT' && ['checkbox', 'radio'].includes(inputType || '')) {
     return true;
   }
 
-  // Skip custom toggles (role-based)
   const role = target.getAttribute('role');
   if (['checkbox', 'switch'].includes(role || '')) {
     return true;
   }
 
-  // Skip body
   if (tagName === 'BODY') return true;
 
-  // Skip editable inputs
   const isEditable =
     tagName === 'TEXTAREA' ||
     (tagName === 'INPUT' && !['button', 'submit', 'reset'].includes(inputType || '')) ||
@@ -34,7 +20,6 @@ export const shouldSkipClick = (target: HTMLElement): boolean => {
 
   if (isEditable) return true;
 
-  // Skip clicks inside decorated input wrappers
   const inputWrapper = target.closest('label, .input-wrapper, .input-icon, .form-field');
   const isInsideInputWrapper = inputWrapper?.querySelector('input, textarea, [contenteditable="true"]');
 

--- a/pages/content/src/utils/events/should-skip-input-tracking.util.ts
+++ b/pages/content/src/utils/events/should-skip-input-tracking.util.ts
@@ -1,8 +1,3 @@
-/**
- * Checks if an input should be skipped for tracking (e.g. button, password).
- * @param {HTMLElement} target
- * @returns {boolean}
- */
 export const shouldSkipInputTracking = (target: HTMLElement): boolean => {
   const inputType = target.getAttribute('type')?.toLowerCase() || '';
   const skipInputTypes = ['button', 'submit', 'reset'];

--- a/pages/content/src/utils/events/system-info/battery-info.util.ts
+++ b/pages/content/src/utils/events/system-info/battery-info.util.ts
@@ -1,6 +1,5 @@
 import type { BatteryInfo } from '@src/interfaces';
 
-/** Retrieves battery charging status and level. */
 export const getBatteryInfo = async (): Promise<BatteryInfo> => {
   if ('getBattery' in navigator) {
     const battery = await (navigator as any).getBattery();

--- a/pages/content/src/utils/events/system-info/detect-emulation.util.ts
+++ b/pages/content/src/utils/events/system-info/detect-emulation.util.ts
@@ -1,6 +1,3 @@
-/**
- * Heuristic to detect whether device emulation mode is likely active.
- */
 export const isLikelyEmulated = (): boolean => {
   const dpr = window.devicePixelRatio;
   const ua = navigator.userAgent;
@@ -16,12 +13,6 @@ export const isLikelyEmulated = (): boolean => {
   return spoofedTouch || suspiciousDesktopUA || suspiciousZoomOrDPR || emulatedButLooksReal;
 };
 
-/**
- * Attempts to detect if DevTools is open by comparing outer and inner window sizes.
- * Useful in combination with `isLikelyEmulated()` to infer responsive testing.
- *
- * @returns Boolean indicating whether DevTools is likely open
- */
 export const isDevToolsOpen = (): boolean => {
   const widthDiff = window.outerWidth - window.innerWidth;
   const heightDiff = window.outerHeight - window.innerHeight;

--- a/pages/content/src/utils/events/system-info/extension-context.util.ts
+++ b/pages/content/src/utils/events/system-info/extension-context.util.ts
@@ -2,14 +2,8 @@ import type { ExtensionContext } from '@src/interfaces';
 
 import packageJsonFile from '../../../../package.json';
 
-/** Returns extension runtime context (extension ID, host, etc.). */
 export const getExtensionContext = (): ExtensionContext => {
-  /**
-   * @todo
-   * create a custom event to get extensionId
-   */
   return {
-    // extensionId: chrome.runtime?.id,
     host: location.hostname,
     version: packageJsonFile.version,
   };

--- a/pages/content/src/utils/events/system-info/incognito-status.util.ts
+++ b/pages/content/src/utils/events/system-info/incognito-status.util.ts
@@ -1,4 +1,3 @@
-/** Detects whether the browser is in incognito mode using the FileSystem API. */
 export const getIncognitoStatus = async (): Promise<boolean> => {
   return new Promise(resolve => {
     const w = window as unknown as {

--- a/pages/content/src/utils/events/system-info/language-info.util.ts
+++ b/pages/content/src/utils/events/system-info/language-info.util.ts
@@ -1,6 +1,5 @@
 import type { LanguageInfo } from '@src/interfaces';
 
-/** Returns user language and language preferences. */
 export const getLanguageInfo = (): LanguageInfo => ({
   language: navigator.language,
   languages: navigator.languages,

--- a/pages/content/src/utils/events/system-info/memory-info.util.ts
+++ b/pages/content/src/utils/events/system-info/memory-info.util.ts
@@ -1,6 +1,5 @@
 import type { MemoryInfo } from '@src/interfaces';
 
-/** Returns memory usage info (if supported). */
 export const getMemoryInfo = (): MemoryInfo | null => {
   const memory = (performance as any).memory;
   return memory

--- a/pages/content/src/utils/events/system-info/network-info.util.ts
+++ b/pages/content/src/utils/events/system-info/network-info.util.ts
@@ -1,6 +1,5 @@
 import type { NetworkInfo } from '@src/interfaces';
 
-/** Returns connection quality details if available. */
 export const getNetworkInfo = (): NetworkInfo | null => {
   const connection =
     (navigator as any).connection || (navigator as any).mozConnection || (navigator as any).webkitConnection;

--- a/pages/content/src/utils/events/system-info/system-info.util.ts
+++ b/pages/content/src/utils/events/system-info/system-info.util.ts
@@ -8,14 +8,6 @@ import { getMemoryInfo } from './memory-info.util';
 import { getNetworkInfo } from './network-info.util';
 import { parseUserAgent } from './user-agent.util';
 
-/**
- * Collects environment information useful for debugging or diagnostics.
- *
- * Includes browser details, OS info, battery status, incognito mode, screen zoom,
- * network conditions, locale, and memory usage.
- *
- * @returns A promise resolving to a structured `SystemInfo` object.
- */
 export const getSystemInfo = async (): Promise<SystemInfo> => {
   const systemInfo = parseUserAgent();
   const [isIncognito, batteryInfo] = await Promise.all([getIncognitoStatus(), getBatteryInfo()]);

--- a/pages/content/src/utils/events/system-info/user-agent.util.ts
+++ b/pages/content/src/utils/events/system-info/user-agent.util.ts
@@ -23,15 +23,9 @@ const getWindowsVersion = async (): Promise<string> => {
   return '';
 };
 
-/** Parses navigator.userAgent to extract browser and OS info. */
 export const parseUserAgent = async (): Promise<{ browser: BrowserInfo; os: OSInfo }> => {
-  //   FIrst approach would be :
-  //   detect browser using browser name and browser version using uaData !
-  // uaData - for browser : Chrome, Edge, Opera, Dia, Brave, Samsung Internet as they are chromium based
-
-  //  for non chromium based browser (Firefox / Safari) running on macos or on lInux
+  // Non-Chromium browsers (Firefox / Safari) — userAgentData isn't available, so parse the UA string.
   if (browserName === 'Unknown' && browserVersion === 'Unknown') {
-    // for firefox
     if (userAgent.includes('firefox') || userAgent.includes('Firefox')) {
       browserName = 'Firefox';
       browserVersion = userAgent.match(/firefox\/([\d.]+)/)?.[1] || '';
@@ -53,8 +47,8 @@ export const parseUserAgent = async (): Promise<{ browser: BrowserInfo; os: OSIn
 
         osVersion = '';
       } else if (matchWin) {
-        // when firefox is running on windows machine
-        // navigator.userAgentData api is not available for NON-Chromium browser so need to output as 10/11
+        // Windows 10 and 11 share NT 10.0 in the UA string — userAgentData (Chromium-only) would
+        // disambiguate, but Firefox can't, so report "10/11".
         osName = 'Windows';
         const match = userAgent.match(/windows nt ([\d.]+)/);
         if (match) {
@@ -69,7 +63,6 @@ export const parseUserAgent = async (): Promise<{ browser: BrowserInfo; os: OSIn
       }
     }
 
-    // for safari
     if ((userAgent.includes('safari') || userAgent.includes('Safari')) && !userAgent.includes('chrome')) {
       browserName = 'Safari';
       browserVersion = userAgent.match(/version\/([\d.]+)/)?.[1] || '';
@@ -78,7 +71,6 @@ export const parseUserAgent = async (): Promise<{ browser: BrowserInfo; os: OSIn
     }
   }
 
-  // now for mobile devices  based browsers like
   if (/iphone|ipad|ipod/.test(userAgent)) {
     osName = 'iOS';
     osVersion = userAgent.match(/OS ([\d_]+)/i)?.[1]?.replace(/_/g, '.') || 'Unknown';
@@ -89,9 +81,7 @@ export const parseUserAgent = async (): Promise<{ browser: BrowserInfo; os: OSIn
     osName = 'Linux';
   }
 
-  // WHEN OS is windows need to configure the OSVERSION
-  // this is applied  for Chromium
-  // Chromium-based browsers (Chrome, Edge, Brave, Opera)
+  // Chromium-based browsers (Chrome, Edge, Brave, Opera) — use userAgentData.
   if (browserName === 'Unknown' && browserVersion === 'Unknown') {
     const brands: Array<{ brand: string; version: string }> = uaData.brands || [];
     const brandInfo =

--- a/pages/content/src/utils/events/system-info/zoom-level.util.ts
+++ b/pages/content/src/utils/events/system-info/zoom-level.util.ts
@@ -1,4 +1,3 @@
-/** Returns zoom level and device pixel ratio. */
 export const getBrowserZoomLevel = () => {
   const pixelRatio = window.devicePixelRatio;
   const zoomLevel = Math.round((window.outerWidth / window.innerWidth) * 100);

--- a/pages/content/src/utils/network/extract-query-params.util.ts
+++ b/pages/content/src/utils/network/extract-query-params.util.ts
@@ -1,4 +1,3 @@
-// Utility to extract query parameters
 export const extractQueryParams = (url: string): Record<string, string> => {
   try {
     const params = new URL(url, window.location.origin).searchParams;

--- a/pages/content/src/utils/network/truncate-response.util.ts
+++ b/pages/content/src/utils/network/truncate-response.util.ts
@@ -1,4 +1,3 @@
-// Utility to truncate large responses
 export const truncateResponse = (responseBody: unknown) => {
   return typeof responseBody === 'string' && responseBody.length > 1000
     ? responseBody.slice(0, 1000) + '... (truncated)'

--- a/pages/content/src/utils/recording/pick-meme-type.util.ts
+++ b/pages/content/src/utils/recording/pick-meme-type.util.ts
@@ -7,5 +7,5 @@ export const pickMimeType = (): MediaRecorderOptions => {
     }
   }
 
-  return {}; // browser will decide
+  return {};
 };

--- a/pages/content/vite.config.mts
+++ b/pages/content/vite.config.mts
@@ -19,7 +19,6 @@ const selfContainedEntriesPlugin = (): Plugin => {
     name: 'self-contained-entries',
     enforce: 'pre',
     generateBundle(_, bundle) {
-      // ── 1. Inline shared chunks ──────────────────────────────────────
       const sharedChunks = new Map<string, (typeof bundle)[string] & { type: 'chunk' }>();
 
       for (const [fileName, info] of Object.entries(bundle)) {
@@ -41,13 +40,12 @@ const selfContainedEntriesPlugin = (): Plugin => {
           const importMatch = code.match(importRe);
           if (!importMatch) continue;
 
-          // Parse import bindings, e.g. "R as RECORD, U as UI"
+          // Parses import bindings like "R as RECORD, U as UI".
           const importBindings = importMatch[1].split(',').map(s => {
             const [imported, local] = s.trim().split(/\s+as\s+/);
             return { imported: imported.trim(), local: (local || imported).trim() };
           });
 
-          // Parse the chunk's export statement
           const exportMatch = chunk.code.match(/export\s*\{\s*([^}]+)\s*\}\s*;?/);
           const exportMap = new Map<string, string>();
           if (exportMatch) {
@@ -57,10 +55,9 @@ const selfContainedEntriesPlugin = (): Plugin => {
             }
           }
 
-          // Strip export from chunk code
           let inlined = chunk.code.replace(/export\s*\{[^}]*\}\s*;?\s*/g, '').trim();
 
-          // Add alias declarations when chunk-local name differs from import-local name
+          // Alias when the chunk-local name differs from the import-local name.
           for (const { imported, local } of importBindings) {
             const chunkLocal = exportMap.get(imported) ?? imported;
             if (chunkLocal !== local) {
@@ -72,13 +69,12 @@ const selfContainedEntriesPlugin = (): Plugin => {
           entry.imports = entry.imports.filter(i => i !== chunkFile);
         }
 
-        // ── 2. Strip `export default` keyword but keep the expression ──
+        // Drop the `export default` keyword but keep the expression so the IIFE still evaluates.
         code = code.replace(/^export\s+default\s+/gm, '');
 
         entry.code = code;
       }
 
-      // Remove shared chunks from the bundle
       for (const name of sharedChunks.keys()) {
         delete bundle[name];
       }

--- a/pages/popup/src/components/capture/capture-content.view.tsx
+++ b/pages/popup/src/components/capture/capture-content.view.tsx
@@ -94,7 +94,7 @@ const CaptureContentViewInner = ({ onActiveTabChange, captureState }: CaptureCon
           await recordingSettingsStorage.setMicPermission(permission);
         }
       } catch {
-        // navigator.permissions.query may not be available (Firefox)
+        // navigator.permissions.query unavailable on Firefox; treat as unknown.
       }
     })();
   }, []);
@@ -151,7 +151,6 @@ const CaptureContentViewInner = ({ onActiveTabChange, captureState }: CaptureCon
       const tab = await getActiveTab();
 
       if (!tab?.id || !tab?.url) {
-        // TODO: show toast "No active tab"
         return;
       }
 
@@ -162,13 +161,11 @@ const CaptureContentViewInner = ({ onActiveTabChange, captureState }: CaptureCon
       const { blocked: rewindBlocked, reason } = isRewindBlocked(tabUrl);
 
       if (rewindBlocked) {
-        // TODO: show toast "Rewind disabled on this site (reason: ...)"
         return;
       }
 
       const freeze = (await sendRuntimeMessageToActiveTab({ type: REWIND.FREEZE, tabId })) as { status: string };
       if (freeze?.status !== 'success') {
-        // TODO: show toast with freezeResp.error
         return;
       }
 
@@ -176,7 +173,6 @@ const CaptureContentViewInner = ({ onActiveTabChange, captureState }: CaptureCon
       window.close();
     } catch (err) {
       console.error('[brie|popup] onOpenRewind failed', err);
-      // TODO: show toast "Failed to open rewind"
     }
   };
 

--- a/pages/popup/src/hooks/use-auth-identity-provider.hook.ts
+++ b/pages/popup/src/hooks/use-auth-identity-provider.hook.ts
@@ -5,25 +5,12 @@ import { AUTH, useStorage } from '@extension/shared';
 import { authIdentityProviderStorage } from '@extension/storage';
 import type { AuthIdentityProviderStorage as AuthFlowState } from '@extension/storage';
 
-/**
- * Hook that launches the “continue with [auth-provider]” flow
- * and stores the resulting access / refresh tokens.
- *
- * @returns An object with:
- *   • `register()` – call to start the flow
- *   • `isLoading`  – `true` while the browser window is open
- *   • `error`      – any error thrown during the flow
- */
 export const useAuthIdentityProvider = () => {
   const [error, setError] = useState<Error | null>(null);
 
   const authFlow = useStorage(authIdentityProviderStorage);
   const setAuthFlow = useCallback((state: AuthFlowState | null) => authIdentityProviderStorage.set(state), []);
 
-  /**
-   * Launches the authentication flow via background message.
-   * Sets active state in storage and handles cleanup automatically.
-   */
   const register = useCallback(async () => {
     if (authFlow?.active) return;
 
@@ -35,8 +22,6 @@ export const useAuthIdentityProvider = () => {
 
       if (!response?.ok) {
         throw new Error(response?.error || 'Auth flow failed');
-      } else {
-        // window.close();
       }
     } catch (e) {
       const err = e instanceof Error ? e : new Error(String(e));
@@ -47,13 +32,6 @@ export const useAuthIdentityProvider = () => {
     }
   }, [authFlow?.active, setAuthFlow]);
 
-  /**
-   * @todo
-   * - Verify if these states are working correctly
-   * - Check if Chrome login is functioning as expected
-   * - Improve logic in background and here in the code
-   * - Decide whether to remove or keep `auth-provider.html` logic, then refactor accordingly
-   */
   return {
     register,
     isLoading: Boolean(authFlow?.active),

--- a/pages/popup/src/popup-content.tsx
+++ b/pages/popup/src/popup-content.tsx
@@ -53,10 +53,8 @@ export const PopupContent = ({
   const isCaptureScreenshotDisabled = useMemo(() => {
     const isGuest = user?.authMethod === AuthMethod.GUEST;
 
-    // Dev or non-guest: no limit
     if (IS_DEV || !isGuest) return false;
 
-    // Guests: block after daily limit
     return isGuest && totalSlicesCreatedToday > 10 && !!activeTab.id;
   }, [totalSlicesCreatedToday, user?.authMethod, activeTab.id]);
 
@@ -123,27 +121,22 @@ export const PopupContent = ({
     return <SettingsContent onBack={handleOnBack} />;
   }
 
-  // Use-case: Pending reload for this tab
   if (currentActiveTab && pendingReloadTabIds.includes(currentActiveTab)) {
     return <PendingReloadView onRefresh={handleOnRefreshPendingTab} />;
   }
 
-  // Use-case: Internal page hint (no capture on chrome://, about://)
   if (internalPage && state !== 'unsaved' && currentActiveTab !== activeTab.id) {
     return <InternalPageView message={t('navigateToWebsite')} />;
   }
 
-  // Use-case: Unsaved capture in another tab
   if (state === 'unsaved' && currentActiveTab !== activeTab.id) {
     return <UnsavedTabView onDiscard={() => handleOnDiscard(activeTab.id)} onOpenActiveTab={handleGoToActiveTab} />;
   }
 
-  // Use-case: Unsaved capture in this tab
   if (state === 'unsaved' && currentActiveTab === activeTab.id) {
     return <UnsavedCurrentTabView onDiscard={() => handleOnDiscard(activeTab.id)} />;
   }
 
-  // Use-case: Jump to active tab
   if (activeTab.id !== currentActiveTab && isCaptureActive)
     return (
       <Button type="button" variant="link" size="sm" className="w-full" onClick={handleGoToActiveTab}>

--- a/tests/e2e/config/wdio.conf.ts
+++ b/tests/e2e/config/wdio.conf.ts
@@ -1,95 +1,17 @@
-/**
- * WebdriverIO v9 configuration file
- * https://webdriver.io/docs/configurationfile
- */
 export const config: WebdriverIO.Config = {
   runner: 'local',
   tsConfigPath: '../tsconfig.json',
-
-  //
-  // ==================
-  // Specify Test Files
-  // ==================
-  // Define which test specs should run. The pattern is relative to the directory
-  // of the configuration file being run.
-  //
-  // The specs are defined as an array of spec files (optionally using wildcards
-  // that will be expanded). The test for each spec file will be run in a separate
-  // worker process. In order to have a group of spec files run in the same worker
-  // process simply enclose them in an array within the specs array.
-  //
-  // The path of the spec files will be resolved relative from the directory
-  // of the config file unless it's absolute.
   specs: ['../specs/**/*.ts'],
-  // Patterns to exclude.
   exclude: [],
-  //
-  // ============
-  // Capabilities
-  // ============
-  // Define your capabilities here. WebdriverIO can run multiple capabilities at the same
-  // time. Depending on the number of capabilities, WebdriverIO launches several test
-  // sessions. Within your capabilities you can overwrite the spec and exclude options in
-  // order to group specific specs to a specific capability.
-  //
-  // First, you can define how many instances should be started at the same time. Let's
-  // say you have 3 different capabilities (Chrome, Firefox, and Safari) and you have
-  // set maxInstances to 1; wdio will spawn 3 processes. Therefore, if you have 10 spec
-  // files and you set maxInstances to 10, all spec files will get tested at the same time
-  // and 30 processes will get spawned. The property handles how many capabilities
-  // from the same test should run tests.
-  //
   maxInstances: 10,
-  //
-  // If you have trouble getting all important capabilities together, check out the
-  // Sauce Labs platform configurator - a great tool to configure your capabilities:
-  // https://saucelabs.com/platform/platform-configurator
-  //
   capabilities: [],
-
-  //
-  // ===================
-  // Test Configurations
-  // ===================
-  // Define all options that are relevant for the WebdriverIO instance here
-  //
-  // Level of logging verbosity: trace | debug | info | warn | error | silent
   logLevel: 'info',
-
-  //
-  // If you only want to run your tests until a specific amount of tests have failed use
-  // bail (default is 0 - don't bail, run all tests).
   bail: 0,
-  //
-  // Default timeout for all waitFor* commands.
   waitforTimeout: 10000,
-
-  //
-  // Default timeout in milliseconds for request
-  // if browser driver or grid doesn't send response
   connectionRetryTimeout: 120000,
-
-  //
-  // Default request retries count
   connectionRetryCount: 3,
-
-  //
-  // Framework you want to run your specs with.
-  // The following are supported: Mocha, Jasmine, and Cucumber
-  // see also: https://webdriver.io/docs/frameworks
-  //
-  // Make sure you have the wdio adapter package for the specific framework installed
-  // before running any tests.
   framework: 'mocha',
-
-  //
-  // Test reporter for stdout.
-  // The only one supported by default is 'dot'
-  // see also: https://webdriver.io/docs/dot-reporter
   reporters: ['spec'],
-
-  // Options to be passed to Mocha.
-  // See the full list at http://mochajs.org/
   mochaOpts: {
     ui: 'bdd',
     timeout: 60000,

--- a/tests/e2e/helpers/theme.ts
+++ b/tests/e2e/helpers/theme.ts
@@ -1,6 +1,3 @@
-/**
- * Helper method to check if user can click on theme button and toggle theme color
- */
 export const canSwitchTheme = async () => {
   const LIGHT_THEME_CLASS = 'bg-slate-50';
   const DARK_THEME_CLASS = 'bg-gray-800';
@@ -16,11 +13,9 @@ export const canSwitchTheme = async () => {
   const initialThemeClass = appClasses.includes(LIGHT_THEME_CLASS) ? LIGHT_THEME_CLASS : DARK_THEME_CLASS;
   const afterClickThemeClass = appClasses.includes(LIGHT_THEME_CLASS) ? DARK_THEME_CLASS : LIGHT_THEME_CLASS;
 
-  // Toggle theme
   await toggleThemeButton.click();
   await expect(app).toHaveElementClass(afterClickThemeClass);
 
-  // Toggle back to initial theme
   await toggleThemeButton.click();
   await expect(app).toHaveElementClass(initialThemeClass);
 };

--- a/tests/e2e/playwright/non-interference.spec.ts
+++ b/tests/e2e/playwright/non-interference.spec.ts
@@ -11,8 +11,6 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 /**
  * Chromium only — Firefox's `firefox.launchPersistentContext` does not support `--load-extension`;
  * Firefox extension testing needs web-ext / Marionette and is intentionally not wired into this spec.
- *
- * Usage: TARGET_URL=https://your-site.com pnpm test:site (defaults to example.com).
  */
 
 const TARGET_URL = process.env.TARGET_URL ?? 'https://www.example.com';
@@ -34,7 +32,7 @@ let userDataDir: string;
 test.beforeAll(async () => {
   userDataDir = mkdtempSync(join(tmpdir(), 'brie-pw-'));
   context = await chromium.launchPersistentContext(userDataDir, {
-    headless: false, // MV3 extensions don't load in old headless; use --headless=new via CI flag below
+    headless: false, // MV3 extensions don't load in old headless; CI passes --headless=new below
     args: [
       `--disable-extensions-except=${EXTENSION_DIR}`,
       `--load-extension=${EXTENSION_DIR}`,
@@ -51,7 +49,6 @@ test.afterAll(async () => {
 test(`extension reaches ${TARGET_URL}`, async () => {
   const page = await context.newPage();
   await page.goto(TARGET_URL, { waitUntil: 'domcontentloaded' });
-  // content-ui injects via document_idle; allow the SPA to settle, then wait for #brie-root.
   await page.waitForFunction(() => !!document.getElementById('brie-root'), null, { timeout: 10_000 });
   expect(await page.locator('#brie-root').count()).toBeGreaterThan(0);
 });
@@ -59,7 +56,6 @@ test(`extension reaches ${TARGET_URL}`, async () => {
 test(`no extension-attributed uncaught errors on ${TARGET_URL}`, async () => {
   const page = await context.newPage();
 
-  // Install error capture before navigation so we catch errors fired during page load.
   await page.addInitScript(() => {
     window.__brieTestErrors = [];
     window.addEventListener('error', e => {

--- a/tests/e2e/specs/page-content-runtime.test.ts
+++ b/tests/e2e/specs/page-content-runtime.test.ts
@@ -7,20 +7,16 @@ describe('Webextension Content Runtime Script', () => {
   });
 
   it('should create runtime element on the page', async () => {
-    // Open the popup
     const extensionPath = await browser.getExtensionPath();
     const popupUrl = `${extensionPath}/popup/index.html`;
     await browser.url(popupUrl);
 
     await expect(browser).toHaveTitle('Popup');
 
-    // Trigger the content script on the popup
-    // button contains "Content Script" text
     const contentScriptButton = await $('button*=Content Script').getElement();
 
     await contentScriptButton.click();
 
-    // Check if id chrome-extension-boilerplate-react-vite-runtime-content-view-root exists on page
     const runtimeElement = await $('#brie-runtime-root').getElement();
 
     await expect(runtimeElement).toBeExisting();

--- a/tests/e2e/utils/extension-path.ts
+++ b/tests/e2e/utils/extension-path.ts
@@ -1,20 +1,9 @@
-/**
- * Returns the Chrome extension path.
- * @param browser
- * @returns path to the Chrome extension
- */
 export const getChromeExtensionPath = async (browser: WebdriverIO.Browser) => {
   await browser.url('chrome://extensions/');
   /**
-   * https://webdriver.io/docs/extension-testing/web-extensions/#test-popup-modal-in-chrome
-   * ```ts
-   * const extensionItem = await $('extensions-item').getElement();
-   * ```
-   * The above code is not working. I guess it's because the shadow root is not accessible.
-   * So I used the following code to access the shadow root manually.
-   *
-   *  @url https://github.com/webdriverio/webdriverio/issues/13521
-   *  @url https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/issues/786
+   * The documented `$('extensions-item')` selector doesn't resolve because the shadow root
+   * isn't auto-pierced — walk it manually instead.
+   * https://github.com/webdriverio/webdriverio/issues/13521
    */
   const extensionItem = await (async () => {
     const extensionsManager = await $('extensions-manager').getElement();
@@ -31,11 +20,6 @@ export const getChromeExtensionPath = async (browser: WebdriverIO.Browser) => {
   return `chrome-extension://${extensionId}`;
 };
 
-/**
- * Returns the Firefox extension path.
- * @param browser
- * @returns path to the Firefox extension
- */
 export const getFirefoxExtensionPath = async (browser: WebdriverIO.Browser) => {
   await browser.url('about:debugging#/runtime/this-firefox');
   const uuidElement = await browser.$('//dt[contains(text(), "Internal UUID")]/following-sibling::dd').getElement();


### PR DESCRIPTION
## Summary

Six simplifier agents dispatched in parallel against non-overlapping scopes (chrome-extension SW + utils, content + content-runtime, content-ui, popup + mic-permission, packages/{shared,storage,ui,vite-config}, tests/e2e).

### What got cut
- \`// fetches the user\` above \`fetchUser()\`-style restatements.
- "Previously..."/"Was X"/"Phase N" refactor archaeology.
- Section banners (\`// === handlers ===\`).
- JSDoc that only repeats parameter names.
- Commented-out code.
- \`@todo\` observational notes without ticket references.
- "For performance" without a specific cost named.

### What stayed
- Browser quirks (Firefox \`chrome.storage.session\` gap, \`adoptedStyleSheets\` bug, MV3 headless extension load).
- Public-API contracts (exported function shapes, custom event names, return semantics).
- Perf notes where the cost is named (\`requestRenderAll coalesces multiple mouse:move into one rAF\`).
- \`@todo #91\`-style notes with ticket refs.
- Magic-string explanations (local extension UUID).
- Hidden invariants (microtask flush ordering, MV3 timer reliability).

### Stats
- 92 files changed
- +95 / -1127 lines
- Net **−1032 lines** of comment noise

### Verified
- \`pnpm type-check\` passes.
- \`pnpm build:chrome:production\` succeeds.

No behavior changes — comments only.