### PR TITLE
fix(deps): pin prettier-plugin-tailwindcss to 0.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "postcss": "^8.5.2",
     "postcss-load-config": "^6.0.1",
     "prettier": "^3.3.3",
-    "prettier-plugin-tailwindcss": "^0.8.0",
+    "prettier-plugin-tailwindcss": "0.7.4",
     "rimraf": "^6.1.3",
     "run-script-os": "^1.1.6",
     "tailwindcss": "^3.4.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,8 +133,8 @@ importers:
         specifier: ^3.3.3
         version: 3.5.3
       prettier-plugin-tailwindcss:
-        specifier: ^0.8.0
-        version: 0.8.0(prettier@3.5.3)
+        specifier: 0.7.4
+        version: 0.7.4(prettier@3.5.3)
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
@@ -6254,8 +6254,8 @@ packages:
     resolution: {integrity: sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==}
     engines: {node: '>=6.0.0'}
 
-  prettier-plugin-tailwindcss@0.8.0:
-    resolution: {integrity: sha512-V8ITGH87yuBDF6JpEZTOVlUz/saAwqb8f3HRgUj8Lh+tGCcrmorhsLpYqzygwFwK0PE2Ib6Mv3M7T/uE2tZV1g==}
+  prettier-plugin-tailwindcss@0.7.4:
+    resolution: {integrity: sha512-UKii4RjY05SNt/WQi6/NcOn/LsT0/ILLXsxygjbRg5/YZelsSu5jTqorYHPDGq4nZy5q5hpCu+XdGZ1xaJEQgw==}
     engines: {node: '>=20.19'}
     peerDependencies:
       '@ianvs/prettier-plugin-sort-imports': '*'
@@ -13569,7 +13569,7 @@ snapshots:
     dependencies:
       fast-diff: 1.3.0
 
-  prettier-plugin-tailwindcss@0.8.0(prettier@3.5.3):
+  prettier-plugin-tailwindcss@0.7.4(prettier@3.5.3):
     dependencies:
       prettier: 3.5.3
 


### PR DESCRIPTION
## Summary
The 0.8.0 release (landed earlier today as part of the dev-dep batch in #320) crashes when parsing `.ts` files: `TypeError: e.charAt is not a function` inside the plugin's TypeScript-parser path. Reproduced in isolation: empty fresh package with `prettier@3.5.3` + `prettier-plugin-tailwindcss@0.8.0` on a trivial `.ts` file → same crash. Downgrading to `0.7.4` (the last working release) restores prettier across the repo.

This is breaking every pre-commit hook and `npm run format` invocation right now.

Pinning to an exact version (no caret) so Dependabot doesn't auto-bump back to 0.8.0 without us re-checking upstream.

## Test plan
- [x] `npx prettier --write tests/e2e/playwright/non-interference.spec.ts` succeeds (was crashing on develop).
- [x] Reproduced 0.8.0 crash in `/tmp/prettier-test` with a fresh install.