### PR TITLE
feat(settings): add custom capture redaction patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ _Record exactly what went wrong, no more back-and-forth emails or messy screensh
 **🛠️ Developer - Ready Reports:**
 _Brie auto-captures console logs, network errors, and user actions so devs get full context instantly._
 
+**🔐 Local redaction controls:**
+_Captured network, storage, and cookie data supports user-defined patterns powered by [Flare Redact](https://github.com/flare-collection/flare-redact)._
+
 **🕒 Save Time, Build Faster:**
 _No wasted hours on unclear bug reports, just fast fixes and better software._
 

--- a/chrome-extension/src/utils/manage-records.util.ts
+++ b/chrome-extension/src/utils/manage-records.util.ts
@@ -8,7 +8,7 @@ import type { Record } from '@src/types';
 import { decodeRequestBody } from './decode-request-body.util';
 
 let skipDomainsCache: string[] = [];
-let customPatternsCache: string[] = [];
+let customPatternsCache = redactionPatternsStorage.getSnapshot() ?? [];
 
 const refreshSkipDomainsFromSnapshot = () => {
   skipDomainsCache = domainSkipListStorage.getSnapshot() ?? [];
@@ -23,7 +23,7 @@ const refreshCustomPatternsFromSnapshot = () => {
   customPatternsCache = redactionPatternsStorage.getSnapshot() ?? [];
 };
 
-void redactionPatternsStorage.get().then(value => {
+const customPatternsReady = redactionPatternsStorage.get().then(value => {
   customPatternsCache = value ?? [];
 });
 redactionPatternsStorage.subscribe(refreshCustomPatternsFromSnapshot);
@@ -74,6 +74,13 @@ export const addOrMergeRecords = async (tabId: number, record: Record): Promise<
 
   if (invalidRecord(record?.url || record?.pageUrl || '')) {
     console.log('[addOrMergeRecords] SKIPPED: Invalid URL');
+    return;
+  }
+
+  try {
+    await customPatternsReady;
+  } catch (error) {
+    console.error('[addOrMergeRecords] Custom redaction settings could not be loaded; record skipped:', error);
     return;
   }
 

--- a/chrome-extension/src/utils/manage-records.util.ts
+++ b/chrome-extension/src/utils/manage-records.util.ts
@@ -1,13 +1,14 @@
 import { v4 as uuidv4 } from 'uuid';
 
 import { deepRedactSensitiveInfo } from '@extension/shared';
-import { domainSkipListStorage } from '@extension/storage';
+import { domainSkipListStorage, redactionPatternsStorage } from '@extension/storage';
 
 import type { Record } from '@src/types';
 
 import { decodeRequestBody } from './decode-request-body.util';
 
 let skipDomainsCache: string[] = [];
+let customPatternsCache: string[] = [];
 
 const refreshSkipDomainsFromSnapshot = () => {
   skipDomainsCache = domainSkipListStorage.getSnapshot() ?? [];
@@ -17,6 +18,15 @@ void domainSkipListStorage.get().then(value => {
   skipDomainsCache = value ?? [];
 });
 domainSkipListStorage.subscribe(refreshSkipDomainsFromSnapshot);
+
+const refreshCustomPatternsFromSnapshot = () => {
+  customPatternsCache = redactionPatternsStorage.getSnapshot() ?? [];
+};
+
+void redactionPatternsStorage.get().then(value => {
+  customPatternsCache = value ?? [];
+});
+redactionPatternsStorage.subscribe(refreshCustomPatternsFromSnapshot);
 
 const MAX_RECORDS_PER_TAB = 5_000;
 const MAX_URL_MAP_PER_TAB = 1_000;
@@ -68,6 +78,7 @@ export const addOrMergeRecords = async (tabId: number, record: Record): Promise<
   }
 
   const skipDomains = skipDomainsCache;
+  const customPatterns = customPatternsCache;
   const tabUrl = record?.url || record?.pageUrl;
 
   if (!tabRecordsMap.has(tabId)) {
@@ -88,7 +99,7 @@ export const addOrMergeRecords = async (tabId: number, record: Record): Promise<
   try {
     if (record.recordType !== 'network') {
       evictOldestIfFull();
-      recordsMap.set(uuid, { uuid, ...deepRedactSensitiveInfo(record, tabUrl, skipDomains) });
+      recordsMap.set(uuid, { uuid, ...deepRedactSensitiveInfo(record, tabUrl, skipDomains, customPatterns) });
       return;
     }
 
@@ -138,13 +149,18 @@ export const addOrMergeRecords = async (tabId: number, record: Record): Promise<
     }
     const { requestBody: baseRequestBody, ...restForRedaction } = baseRecord;
 
-    const redactedRest = deepRedactSensitiveInfo(restForRedaction, tabUrl, skipDomains);
+    const redactedRest = deepRedactSensitiveInfo(restForRedaction, tabUrl, skipDomains, customPatterns);
     let safeRequestBody: any = undefined;
 
     if (baseRequestBody?.parsed || baseRequestBody?.decoded) {
       safeRequestBody = {
         ...(baseRequestBody?.raw ? { raw: baseRequestBody.raw } : {}),
-        parsed: deepRedactSensitiveInfo(baseRequestBody.parsed ?? baseRequestBody.decoded, tabUrl, skipDomains),
+        parsed: deepRedactSensitiveInfo(
+          baseRequestBody.parsed ?? baseRequestBody.decoded,
+          tabUrl,
+          skipDomains,
+          customPatterns,
+        ),
       };
     }
 

--- a/packages/i18n/locales/en/messages.json
+++ b/packages/i18n/locales/en/messages.json
@@ -589,6 +589,21 @@
   "noDomains": {
     "message": "No domains added yet. Sensitive info is only skipped on localhost by default."
   },
+  "customRedactionPatterns": {
+    "message": "Custom redaction patterns"
+  },
+  "customRedactionPatternsDescription": {
+    "message": "Local regular expressions applied to captured network, storage, cookie, and console data."
+  },
+  "redactionPatternPlaceholder": {
+    "message": "e.g. /api[_-]?key=[^&]+/gi"
+  },
+  "noCustomRedactionPatterns": {
+    "message": "No custom patterns added. Brie's built-in redaction remains active."
+  },
+  "invalidRedactionPattern": {
+    "message": "Enter a valid, safe regular expression that does not match empty text."
+  },
   "noCaptureData": {
     "message": "No capture data available. Start a recording first."
   },

--- a/packages/i18n/locales/es/messages.json
+++ b/packages/i18n/locales/es/messages.json
@@ -574,6 +574,21 @@
   "noDomains": {
     "message": "Aún no se han agregado dominios. La información sensible solo se omite en localhost por defecto."
   },
+  "customRedactionPatterns": {
+    "message": "Patrones de redacción personalizados"
+  },
+  "customRedactionPatternsDescription": {
+    "message": "Expresiones regulares locales aplicadas a datos capturados de red, almacenamiento, cookies y consola."
+  },
+  "redactionPatternPlaceholder": {
+    "message": "p. ej. /api[_-]?key=[^&]+/gi"
+  },
+  "noCustomRedactionPatterns": {
+    "message": "No hay patrones personalizados. La redacción integrada de Brie sigue activa."
+  },
+  "invalidRedactionPattern": {
+    "message": "Introduce una expresión regular válida y segura que no coincida con texto vacío."
+  },
   "noCaptureData": {
     "message": "No capture data available. Start a recording first."
   },

--- a/packages/i18n/locales/fil/messages.json
+++ b/packages/i18n/locales/fil/messages.json
@@ -574,6 +574,21 @@
   "noDomains": {
     "message": "Wala pang naidagdag na domain. Ang sensitibong impormasyon ay nili-laktawan lang sa localhost bilang default."
   },
+  "customRedactionPatterns": {
+    "message": "Mga custom na pattern ng redaction"
+  },
+  "customRedactionPatternsDescription": {
+    "message": "Mga lokal na regular expression para sa nakuhang network, storage, cookie, at console data."
+  },
+  "redactionPatternPlaceholder": {
+    "message": "hal. /api[_-]?key=[^&]+/gi"
+  },
+  "noCustomRedactionPatterns": {
+    "message": "Wala pang custom na pattern. Aktibo pa rin ang built-in redaction ng Brie."
+  },
+  "invalidRedactionPattern": {
+    "message": "Maglagay ng wasto at ligtas na regular expression na hindi tumutugma sa walang laman na text."
+  },
   "noCaptureData": {
     "message": "No capture data available. Start a recording first."
   },

--- a/packages/i18n/locales/hi/messages.json
+++ b/packages/i18n/locales/hi/messages.json
@@ -574,6 +574,21 @@
   "noDomains": {
     "message": "अभी तक कोई डोमेन नहीं जोड़ा गया। संवेदनशील जानकारी डिफ़ॉल्ट रूप से केवल localhost पर छोड़ी जाती है।"
   },
+  "customRedactionPatterns": {
+    "message": "कस्टम रिडैक्शन पैटर्न"
+  },
+  "customRedactionPatternsDescription": {
+    "message": "कैप्चर किए गए नेटवर्क, स्टोरेज, कुकी और कंसोल डेटा पर लागू स्थानीय रेगुलर एक्सप्रेशन।"
+  },
+  "redactionPatternPlaceholder": {
+    "message": "जैसे /api[_-]?key=[^&]+/gi"
+  },
+  "noCustomRedactionPatterns": {
+    "message": "कोई कस्टम पैटर्न नहीं जोड़ा गया। Brie का बिल्ट-इन रिडैक्शन सक्रिय रहेगा।"
+  },
+  "invalidRedactionPattern": {
+    "message": "ऐसा मान्य और सुरक्षित रेगुलर एक्सप्रेशन दर्ज करें जो खाली टेक्स्ट से मेल न खाए।"
+  },
   "noCaptureData": {
     "message": "No capture data available. Start a recording first."
   },

--- a/packages/i18n/locales/it/messages.json
+++ b/packages/i18n/locales/it/messages.json
@@ -574,6 +574,21 @@
   "noDomains": {
     "message": "Nessun dominio aggiunto. Le informazioni sensibili vengono saltate solo su localhost per impostazione predefinita."
   },
+  "customRedactionPatterns": {
+    "message": "Pattern di redazione personalizzati"
+  },
+  "customRedactionPatternsDescription": {
+    "message": "Espressioni regolari locali applicate ai dati acquisiti di rete, archiviazione, cookie e console."
+  },
+  "redactionPatternPlaceholder": {
+    "message": "es. /api[_-]?key=[^&]+/gi"
+  },
+  "noCustomRedactionPatterns": {
+    "message": "Nessun pattern personalizzato. La redazione integrata di Brie rimane attiva."
+  },
+  "invalidRedactionPattern": {
+    "message": "Inserisci un'espressione regolare valida e sicura che non corrisponda a testo vuoto."
+  },
   "noCaptureData": {
     "message": "No capture data available. Start a recording first."
   },

--- a/packages/i18n/locales/ro/messages.json
+++ b/packages/i18n/locales/ro/messages.json
@@ -574,6 +574,21 @@
   "noDomains": {
     "message": "Niciun domeniu adăugat încă. Informațiile sensibile sunt omise doar pe localhost în mod implicit."
   },
+  "customRedactionPatterns": {
+    "message": "Modele de redactare personalizate"
+  },
+  "customRedactionPatternsDescription": {
+    "message": "Expresii regulate locale aplicate datelor capturate din rețea, stocare, cookie-uri și consolă."
+  },
+  "redactionPatternPlaceholder": {
+    "message": "ex. /api[_-]?key=[^&]+/gi"
+  },
+  "noCustomRedactionPatterns": {
+    "message": "Nu există modele personalizate. Redactarea integrată Brie rămâne activă."
+  },
+  "invalidRedactionPattern": {
+    "message": "Introdu o expresie regulată validă și sigură care nu se potrivește cu textul gol."
+  },
   "noCaptureData": {
     "message": "No capture data available. Start a recording first."
   },

--- a/packages/i18n/locales/ru/messages.json
+++ b/packages/i18n/locales/ru/messages.json
@@ -574,6 +574,21 @@
   "noDomains": {
     "message": "Домены ещё не добавлены. Конфиденциальная информация пропускается только на localhost по умолчанию."
   },
+  "customRedactionPatterns": {
+    "message": "Пользовательские шаблоны редактирования"
+  },
+  "customRedactionPatternsDescription": {
+    "message": "Локальные регулярные выражения для записанных сетевых данных, хранилища, cookie и консоли."
+  },
+  "redactionPatternPlaceholder": {
+    "message": "например /api[_-]?key=[^&]+/gi"
+  },
+  "noCustomRedactionPatterns": {
+    "message": "Пользовательские шаблоны не добавлены. Встроенная защита Brie продолжает работать."
+  },
+  "invalidRedactionPattern": {
+    "message": "Введите корректное и безопасное регулярное выражение, которое не совпадает с пустым текстом."
+  },
   "noCaptureData": {
     "message": "No capture data available. Start a recording first."
   },

--- a/packages/i18n/locales/uk/messages.json
+++ b/packages/i18n/locales/uk/messages.json
@@ -574,6 +574,21 @@
   "noDomains": {
     "message": "Домени ще не додано. Конфіденційна інформація пропускається лише на localhost за замовчуванням."
   },
+  "customRedactionPatterns": {
+    "message": "Користувацькі шаблони редагування"
+  },
+  "customRedactionPatternsDescription": {
+    "message": "Локальні регулярні вирази для записаних мережевих даних, сховища, cookie та консолі."
+  },
+  "redactionPatternPlaceholder": {
+    "message": "наприклад /api[_-]?key=[^&]+/gi"
+  },
+  "noCustomRedactionPatterns": {
+    "message": "Користувацькі шаблони не додано. Вбудований захист Brie залишається активним."
+  },
+  "invalidRedactionPattern": {
+    "message": "Введіть коректний і безпечний регулярний вираз, який не збігається з порожнім текстом."
+  },
   "noCaptureData": {
     "message": "No capture data available. Start a recording first."
   },

--- a/packages/shared/lib/utils/custom-redaction-pattern.util.ts
+++ b/packages/shared/lib/utils/custom-redaction-pattern.util.ts
@@ -1,0 +1,113 @@
+import { compilePolicy } from 'flare-redact';
+import type { Detector } from 'flare-redact';
+
+import { REDACTED_KEYWORD } from '../constants/redacted-keyword.constants.js';
+
+const MAX_PATTERN_LENGTH = 256;
+const SAFE_FLAGS = /^[gimsu]*$/;
+const BACKREFERENCE = /\\[1-9]/;
+const NESTED_QUANTIFIER = /\([^)]*(?:[+*]|\{\d+(?:,\d*)?\})[^)]*\)(?:[+*]|\{\d+(?:,\d*)?\})/;
+
+interface ParsedRedactionPattern {
+  source: string;
+  flags: string;
+}
+
+type RedactionPatternValidation =
+  | { valid: true; parsed: ParsedRedactionPattern }
+  | { valid: false; reason: 'empty' | 'too-long' | 'flags' | 'unsafe' | 'empty-match' | 'syntax' };
+
+const isEscaped = (value: string, index: number): boolean => {
+  let backslashes = 0;
+  for (let i = index - 1; i >= 0 && value[i] === '\\'; i--) backslashes++;
+  return backslashes % 2 === 1;
+};
+
+const splitExpression = (expression: string): ParsedRedactionPattern | null => {
+  const trimmed = expression.trim();
+  if (!trimmed) return null;
+
+  if (!trimmed.startsWith('/')) return { source: trimmed, flags: 'gi' };
+
+  let closingSlash = -1;
+  for (let i = trimmed.length - 1; i > 0; i--) {
+    if (trimmed[i] === '/' && !isEscaped(trimmed, i)) {
+      closingSlash = i;
+      break;
+    }
+  }
+
+  if (closingSlash <= 0) return null;
+  return {
+    source: trimmed.slice(1, closingSlash),
+    flags: trimmed.slice(closingSlash + 1),
+  };
+};
+
+const validateCustomRedactionPattern = (expression: string): RedactionPatternValidation => {
+  const trimmed = expression.trim();
+  if (!trimmed) return { valid: false, reason: 'empty' };
+  if (trimmed.length > MAX_PATTERN_LENGTH) return { valid: false, reason: 'too-long' };
+
+  const parsed = splitExpression(trimmed);
+  if (!parsed?.source) return { valid: false, reason: 'syntax' };
+  if (!SAFE_FLAGS.test(parsed.flags) || new Set(parsed.flags).size !== parsed.flags.length) {
+    return { valid: false, reason: 'flags' };
+  }
+  if (BACKREFERENCE.test(parsed.source) || NESTED_QUANTIFIER.test(parsed.source)) {
+    return { valid: false, reason: 'unsafe' };
+  }
+
+  try {
+    const candidate = new RegExp(parsed.source, parsed.flags);
+    if (candidate.test('')) return { valid: false, reason: 'empty-match' };
+  } catch {
+    return { valid: false, reason: 'syntax' };
+  }
+
+  return { valid: true, parsed };
+};
+
+let cachedKey = '';
+let cachedPolicy: ReturnType<typeof compilePolicy> | null = null;
+
+const resolvePolicy = (expressions: string[]) => {
+  const parsed = expressions.flatMap(expression => {
+    const validation = validateCustomRedactionPattern(expression);
+    return validation.valid ? [validation.parsed] : [];
+  });
+  const key = JSON.stringify(parsed);
+
+  if (key === cachedKey) return cachedPolicy;
+  cachedKey = key;
+
+  if (parsed.length === 0) {
+    cachedPolicy = null;
+    return null;
+  }
+
+  const detectors: Detector[] = parsed.map(({ source, flags }, index) => ({
+    id: `custom_capture_${index}`,
+    label: 'Custom capture pattern',
+    why: 'Matches a user-configured local redaction expression.',
+    pattern: new RegExp(source, flags),
+    default: false,
+    risk: 'critical',
+  }));
+
+  cachedPolicy = compilePolicy({
+    custom: detectors,
+    only: detectors.map(detector => detector.id),
+    redactKeys: false,
+    mask: REDACTED_KEYWORD,
+  });
+  return cachedPolicy;
+};
+
+const redactCustomPatterns = <T>(input: T, expressions: string[] = []): T => {
+  const policy = resolvePolicy(expressions);
+  return policy ? policy.redact(input) : input;
+};
+
+export { redactCustomPatterns, validateCustomRedactionPattern };
+export type { ParsedRedactionPattern, RedactionPatternValidation };

--- a/packages/shared/lib/utils/custom-redaction-pattern.util.ts
+++ b/packages/shared/lib/utils/custom-redaction-pattern.util.ts
@@ -5,7 +5,7 @@ import { REDACTED_KEYWORD } from '../constants/redacted-keyword.constants.js';
 
 const MAX_PATTERN_LENGTH = 256;
 const SAFE_FLAGS = /^[gimsu]*$/;
-const BACKREFERENCE = /\\[1-9]/;
+const BACKREFERENCE = /\\(?:[1-9]|k<[^>]+>)/;
 const NESTED_QUANTIFIER = /\([^)]*(?:[+*]|\{\d+(?:,\d*)?\})[^)]*\)(?:[+*]|\{\d+(?:,\d*)?\})/;
 
 interface ParsedRedactionPattern {

--- a/packages/shared/lib/utils/index.ts
+++ b/packages/shared/lib/utils/index.ts
@@ -1,5 +1,11 @@
 export type { ValueOf } from './shared-types.js';
 export { deepRedactSensitiveInfo } from './redact-sensitive-info.util.js';
+export {
+  redactCustomPatterns,
+  validateCustomRedactionPattern,
+  type ParsedRedactionPattern,
+  type RedactionPatternValidation,
+} from './custom-redaction-pattern.util.js';
 export { isNonProduction } from './is-non-production.util.js';
 export { isValidJSON } from './is-valid-json.util.js';
 export { safePostMessage } from './safe-post-message.util.js';

--- a/packages/shared/lib/utils/redact-sensitive-info.util.ts
+++ b/packages/shared/lib/utils/redact-sensitive-info.util.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { redactCustomPatterns } from './custom-redaction-pattern.util.js';
 import { isNonProduction } from './is-non-production.util.js';
 import { REDACTED_KEYWORD } from '../constants/redacted-keyword.constants.js';
 import { EXEMPT_KEYS, keyMatches, NON_SENSITIVE_KEYS, STRONG_KEYS } from '../constants/sensitive-keywords.constants.js';
@@ -143,9 +144,16 @@ const isSkipDomain = (url?: string, skipDomains?: string[]): boolean => {
 
 /**
  * Deeply redacts sensitive information. Skips redaction in non-production
- * environments or when the URL matches a domain in `skipDomains`.
+ * environments or when the URL matches a domain in `skipDomains`. Valid
+ * `customPatterns` are applied after Brie's built-in sensitive-data rules.
  */
-export const deepRedactSensitiveInfo = (input: any, url?: string, skipDomains?: string[]): any => {
+export const deepRedactSensitiveInfo = (
+  input: any,
+  url?: string,
+  skipDomains?: string[],
+  customPatterns: string[] = [],
+): any => {
   const shouldSkipRedaction = isNonProduction(url) || isSkipDomain(url, skipDomains);
-  return deepRedactInternal(input, shouldSkipRedaction);
+  const redacted = deepRedactInternal(input, shouldSkipRedaction);
+  return shouldSkipRedaction ? redacted : redactCustomPatterns(redacted, customPatterns);
 };

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -19,10 +19,14 @@
     "lint": "eslint .",
     "lint:fix": "pnpm lint --fix",
     "format": "prettier . --write --ignore-path ../../.prettierignore",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "pnpm ready && node --test test/*.test.mjs"
   },
   "devDependencies": {
     "@extension/storage": "workspace:*",
     "@extension/tsconfig": "workspace:*"
+  },
+  "dependencies": {
+    "flare-redact": "^1.4.1"
   }
 }

--- a/packages/shared/test/custom-redaction.test.mjs
+++ b/packages/shared/test/custom-redaction.test.mjs
@@ -22,6 +22,7 @@ test('rejects empty matches, backreferences, and nested quantifiers', () => {
   assert.equal(validateCustomRedactionPattern('/a*/g').valid, false);
   assert.equal(validateCustomRedactionPattern('/(a+)+$/g').valid, false);
   assert.equal(validateCustomRedactionPattern('/(secret)\\1/g').valid, false);
+  assert.equal(validateCustomRedactionPattern('/(?<secret>token)\\k<secret>/g').valid, false);
 });
 
 test('redacts every nested match without mutating the captured record', () => {

--- a/packages/shared/test/custom-redaction.test.mjs
+++ b/packages/shared/test/custom-redaction.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  redactCustomPatterns,
+  validateCustomRedactionPattern,
+} from '../dist/lib/utils/custom-redaction-pattern.util.js';
+import { deepRedactSensitiveInfo } from '../dist/lib/utils/redact-sensitive-info.util.js';
+
+test('validates literal and raw custom patterns', () => {
+  assert.deepEqual(validateCustomRedactionPattern('/api[_-]?key=[^&]+/gi'), {
+    valid: true,
+    parsed: { source: 'api[_-]?key=[^&]+', flags: 'gi' },
+  });
+  assert.deepEqual(validateCustomRedactionPattern('session-secret-[a-z0-9]+'), {
+    valid: true,
+    parsed: { source: 'session-secret-[a-z0-9]+', flags: 'gi' },
+  });
+});
+
+test('rejects empty matches, backreferences, and nested quantifiers', () => {
+  assert.equal(validateCustomRedactionPattern('/a*/g').valid, false);
+  assert.equal(validateCustomRedactionPattern('/(a+)+$/g').valid, false);
+  assert.equal(validateCustomRedactionPattern('/(secret)\\1/g').valid, false);
+});
+
+test('redacts every nested match without mutating the captured record', () => {
+  const record = {
+    url: 'https://example.com/?api_key=abc123',
+    storage: [{ key: 'custom', value: 'session-secret-deadbeef' }],
+  };
+  const safe = redactCustomPatterns(record, ['/api[_-]?key=[^&]+/gi', '/session-secret-[a-z0-9]+/gi']);
+
+  assert.equal(record.url, 'https://example.com/?api_key=abc123');
+  assert.equal(safe.url, 'https://example.com/?[REDACTED_BY_BRIE]');
+  assert.equal(safe.storage[0].value, '[REDACTED_BY_BRIE]');
+});
+
+test('runs custom patterns after the built-in capture redactor', () => {
+  const safe = deepRedactSensitiveInfo(
+    { password: 'built-in-secret', note: 'tenant-code-customer-42' },
+    'https://app.example.com',
+    [],
+    ['/tenant-code-[a-z0-9-]+/gi'],
+  );
+
+  assert.deepEqual(safe, {
+    password: '[REDACTED_BY_BRIE]',
+    note: '[REDACTED_BY_BRIE]',
+  });
+});

--- a/packages/storage/lib/impl/index.ts
+++ b/packages/storage/lib/impl/index.ts
@@ -25,3 +25,4 @@ export * from './theme.storage.js';
 export * from './user-uuid.storage.js';
 export * from './pending-reload-tabs.storage.js';
 export * from './domain-skip-list.storage.js';
+export * from './redaction-patterns.storage.js';

--- a/packages/storage/lib/impl/redaction-patterns.storage.ts
+++ b/packages/storage/lib/impl/redaction-patterns.storage.ts
@@ -1,0 +1,35 @@
+import { createStorage } from '../base/base.js';
+import { StorageEnum } from '../base/enums.js';
+import type { BaseStorage } from '../base/types.js';
+
+const MAX_CUSTOM_REDACTION_PATTERNS = 25;
+
+type RedactionPatternsStorage = BaseStorage<string[]> & {
+  addPattern: (pattern: string) => Promise<void>;
+  removePattern: (pattern: string) => Promise<void>;
+};
+
+const storage = createStorage<string[]>('custom-redaction-patterns', [], {
+  storageEnum: StorageEnum.Local,
+  liveUpdate: true,
+});
+
+const redactionPatternsStorage: RedactionPatternsStorage = {
+  ...storage,
+
+  async addPattern(pattern: string) {
+    const normalized = pattern.trim();
+    if (!normalized) return;
+
+    await storage.set(current => {
+      if (current.includes(normalized) || current.length >= MAX_CUSTOM_REDACTION_PATTERNS) return current;
+      return [...current, normalized];
+    });
+  },
+
+  async removePattern(pattern: string) {
+    await storage.set(current => current.filter(value => value !== pattern));
+  },
+};
+
+export { MAX_CUSTOM_REDACTION_PATTERNS, redactionPatternsStorage };

--- a/pages/popup/src/components/settings/content.settings.tsx
+++ b/pages/popup/src/components/settings/content.settings.tsx
@@ -1,13 +1,16 @@
 import { useState } from 'react';
 
 import { t } from '@extension/i18n';
-import { useStorage } from '@extension/shared';
-import { domainSkipListStorage } from '@extension/storage';
+import { useStorage, validateCustomRedactionPattern } from '@extension/shared';
+import { MAX_CUSTOM_REDACTION_PATTERNS, domainSkipListStorage, redactionPatternsStorage } from '@extension/storage';
 import { Button, Icon, Input, Separator } from '@extension/ui';
 
 export const SettingsContent = ({ onBack }: { onBack: () => void }) => {
   const domains = useStorage(domainSkipListStorage);
+  const customPatterns = useStorage(redactionPatternsStorage);
   const [newDomain, setNewDomain] = useState('');
+  const [newPattern, setNewPattern] = useState('');
+  const [patternError, setPatternError] = useState('');
 
   const handleAddDomain = async () => {
     const trimmed = newDomain.trim();
@@ -21,10 +24,32 @@ export const SettingsContent = ({ onBack }: { onBack: () => void }) => {
     await domainSkipListStorage.removeDomain(domain);
   };
 
+  const handleAddPattern = async () => {
+    const trimmed = newPattern.trim();
+    const validation = validateCustomRedactionPattern(trimmed);
+
+    if (!validation.valid) {
+      setPatternError(t('invalidRedactionPattern'));
+      return;
+    }
+
+    await redactionPatternsStorage.addPattern(trimmed);
+    setNewPattern('');
+    setPatternError('');
+  };
+
+  const handleRemovePattern = async (pattern: string) => {
+    await redactionPatternsStorage.removePattern(pattern);
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
       handleAddDomain();
     }
+  };
+
+  const handlePatternKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') handleAddPattern();
   };
 
   return (
@@ -40,7 +65,7 @@ export const SettingsContent = ({ onBack }: { onBack: () => void }) => {
 
       <div className="mt-3">
         <h3 className="text-sm font-medium">{t('domainSkipList')}</h3>
-        <p className="text-muted-foreground mt-1 text-xs">{t('domainSkipListDescription')}</p>
+        <p className="mt-1 text-xs text-muted-foreground">{t('domainSkipListDescription')}</p>
 
         <div className="mt-3 flex gap-x-2">
           <Input
@@ -63,7 +88,7 @@ export const SettingsContent = ({ onBack }: { onBack: () => void }) => {
         </div>
 
         <div className="mt-3 space-y-1">
-          {domains.length === 0 && <p className="text-muted-foreground text-xs">{t('noDomains')}</p>}
+          {domains.length === 0 && <p className="text-xs text-muted-foreground">{t('noDomains')}</p>}
 
           {domains.map(domain => (
             <div
@@ -75,6 +100,60 @@ export const SettingsContent = ({ onBack }: { onBack: () => void }) => {
                 size="icon"
                 className="size-6 text-red-500"
                 onClick={() => handleRemoveDomain(domain)}>
+                <Icon name="X" className="size-3.5" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <Separator className="my-4 h-px bg-gray-900/5 dark:bg-gray-800" />
+
+      <div>
+        <h3 className="text-sm font-medium">{t('customRedactionPatterns')}</h3>
+        <p className="mt-1 text-xs text-muted-foreground">{t('customRedactionPatternsDescription')}</p>
+
+        <div className="mt-3 flex gap-x-2">
+          <Input
+            type="text"
+            value={newPattern}
+            onChange={e => {
+              setNewPattern(e.target.value);
+              setPatternError('');
+            }}
+            onKeyDown={handlePatternKeyDown}
+            placeholder={t('redactionPatternPlaceholder')}
+            aria-invalid={Boolean(patternError)}
+            className="h-8 text-xs"
+          />
+          <Button
+            type="button"
+            size="sm"
+            className="h-8 shrink-0"
+            onClick={handleAddPattern}
+            disabled={!newPattern.trim() || customPatterns.length >= MAX_CUSTOM_REDACTION_PATTERNS}>
+            <Icon name="Plus" className="mr-1 size-3.5" />
+            {t('addDomain')}
+          </Button>
+        </div>
+
+        {patternError && <p className="mt-1 text-xs text-red-500">{patternError}</p>}
+
+        <div className="mt-3 space-y-1">
+          {customPatterns.length === 0 && (
+            <p className="text-xs text-muted-foreground">{t('noCustomRedactionPatterns')}</p>
+          )}
+
+          {customPatterns.map(pattern => (
+            <div
+              key={pattern}
+              className="flex items-center justify-between rounded-md px-2 py-1.5 hover:bg-slate-50 dark:hover:bg-slate-800">
+              <code className="max-w-[240px] truncate text-xs text-slate-700 dark:text-slate-300">{pattern}</code>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-6 text-red-500"
+                onClick={() => handleRemovePattern(pattern)}>
                 <Icon name="X" className="size-3.5" />
               </Button>
             </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,6 +257,10 @@ importers:
         version: link:../tsconfig
 
   packages/shared:
+    dependencies:
+      flare-redact:
+        specifier: ^1.4.1
+        version: 1.4.1
     devDependencies:
       '@extension/storage':
         specifier: workspace:*
@@ -4922,6 +4926,11 @@ packages:
   find-up@6.3.0:
     resolution: {integrity: sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  flare-redact@1.4.1:
+    resolution: {integrity: sha512-id4Ayj+dYJfVuMgQXWRaEwLv3ZkPgiudufnkrEaYHvUdHP8O6SN3a4a1Cnlt7bJchpHgdf5HVyV8vDxtrGv8bQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
@@ -12136,6 +12145,10 @@ snapshots:
     dependencies:
       locate-path: 7.2.0
       path-exists: 5.0.0
+
+  flare-redact@1.4.1:
+    dependencies:
+      undici-types: 6.21.0
 
   flat-cache@4.0.1:
     dependencies:


### PR DESCRIPTION
## Purpose of the PR*

Closes #92 by letting users add local regular expressions that are applied to captured request, storage, cookie, and console data before it is retained by the background record store.

## Priority*

- [ ] High: This PR needs to be merged first, before other tasks.
- [x] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Changes*

- adds a Settings UI for adding and removing custom redaction expressions
- stores at most 25 local expressions and limits each expression to 256 characters
- validates syntax and rejects duplicate/unsupported flags, empty matches, numeric/named backreferences, and common nested-quantifier patterns
- keeps Brie's built-in redaction active, then applies valid custom patterns through a cached Flare Redact policy
- applies the policy to network, storage, cookie, and console records before persistence
- waits for custom-pattern storage to load before the first capture and skips the record if those privacy settings cannot be read
- localizes the UI across all existing locales and adds focused tests and documentation

## How to check the feature

1. Open Settings and add a pattern such as `/tenant-code-[a-z0-9-]+/gi`.
2. Start a recording that captures the matching value in a request, storage value, cookie, or console entry.
3. Confirm that the captured record contains `[REDACTED_BY_BRIE]` while unrelated values remain unchanged.
4. Try an invalid pattern such as `/(a+)+$/g` and confirm that it is rejected.

Verification performed:

- `pnpm --filter @extension/shared test`
- `pnpm type-check`
- `pnpm base-build`
- ESLint and Prettier on every changed TypeScript/TSX/JSON file

## Reference

- #92
- [Flare Redact](https://github.com/flare-collection/flare-redact)

Disclosure: I maintain Flare Redact, the library used to compile and apply the custom structured-data policy.
